### PR TITLE
small fixes to allow initial density matrix for faster noisy sampling with cirq

### DIFF
--- a/qsdk/backendbuddy/simulator.py
+++ b/qsdk/backendbuddy/simulator.py
@@ -108,8 +108,9 @@ class Simulator:
         if source_circuit.width == 0:
             raise ValueError("Cannot simulate an empty circuit (e.g identity unitary) with unknown number of qubits.")
 
-        # If the unitary is the identity (no gates), no need for simulation: return all-zero state
-        if source_circuit.size == 0:
+        # If the unitary is the identity (no gates) and no noise model, no need for simulation:
+        # return all-zero state or sample from statevector
+        if source_circuit.size == 0 and not self._noise_model:
             if initial_statevector is not None:
                 statevector = initial_statevector
                 frequencies = self._statevector_to_frequencies(initial_statevector)
@@ -392,7 +393,7 @@ class Simulator:
         n_qubits = state_prep_circuit.width
         if not self.statevector_available or state_prep_circuit.is_mixed_state or self._noise_model:
             initial_circuit = state_prep_circuit
-            if initial_statevector is not None:
+            if initial_statevector is not None and not self.statevector_available:
                 raise ValueError(f'Backend {self._target} does not support statevectors')
             else:
                 updated_statevector = initial_statevector


### PR DESCRIPTION
The cirq backend uses a density matrix simulator for noisy simulation. This allows a user to propagate the full noisy state and then sample from the density matrix at the end.

This PR is small fixes that allows a user to generate classical shadows faster using the cirq backend.
1) Run the noisy state prep circuit and `return_statevector=True` to return the `noisy_density_matrix`.
2) Only run the smaller unitary circuits on `initial_statevector=noisy_density_matrix`