### PR TITLE
Always run backend installation

### DIFF
--- a/tangelo/toolboxes/operators/operators.py
+++ b/tangelo/toolboxes/operators/operators.py
@@ -54,7 +54,7 @@ class QubitHamiltonian(QubitOperator):
     def __init__(self, mapping, up_then_down, *args, **kwargs):
         super(QubitOperator, self).__init__(*args, **kwargs)
         self.mapping = mapping
-        self.up_then_down=up_then_down
+        self.up_then_down = up_then_down
 
     @property
     def n_terms(self):


### PR DESCRIPTION
Added 2 lines in github actions to fix a behavior when `pycodestyle` tests are failing (it prevents installation of the optional backends, thus qiskit and other tangelo tests are failing).