### PR TITLE
Fix for issue 98

### DIFF
--- a/tangelo/linq/qpu_connection/qemist_cloud_connection.py
+++ b/tangelo/linq/qpu_connection/qemist_cloud_connection.py
@@ -68,7 +68,7 @@ def job_status(qemist_cloud_job_id):
         res = util.get_problem_status(qemist_cloud_job_id)
     except NameError:
         raise ModuleNotFoundError("job_status function needs qemist_client.util module.")
-        
+
     return res
 
 


### PR DESCRIPTION
Fix for #98. The `job_estimate` function needs to be accessible without `qemist_client`. I thought of 3 solutions:
- Moving `from .. import ...` inside the function
- Moving `job_estimate` to another file. 
- Catching the inexplicit error to throw a meaningful error (done in this PR).

If you have other ideas I can try them.