### PR TITLE
Estimate QPU cost with QEMIST Cloud API.

### DIFF
--- a/tangelo/linq/qpu_connection/qemist_cloud_connection.py
+++ b/tangelo/linq/qpu_connection/qemist_cloud_connection.py
@@ -127,10 +127,10 @@ def job_result(qemist_cloud_job_id):
 
 
 def job_estimate(circuit, n_shots, backend=None):
-    """Returns an estimate of the cost of running an experiment, for a specified backend 
-    or all backends available. Some service providers care about the 
+    """Returns an estimate of the cost of running an experiment, for a specified backend
+    or all backends available. Some service providers care about the
     complexity / structure of the input quantum circuit, some do not.
-    
+
     The backend identifier strings that a user can provide as argument can be obtained
     by calling this function without specifying a backend. They appear as keys in
     the returned dictionary. These strings may change with time, as we adjust to the


### PR DESCRIPTION
Changing this from a function in Tangelo to a server-side call in QEMIST Cloud will allow users to get the most current prices without having to update to a newer version of Tangelo.

This is dependent on a change that hasn't been merged into the QEMIST Cloud mainline yet. Will open the PR when that's ready. In the meantime, please leave any feedback you have.