### PR TITLE
switched qulacs expectation call

### DIFF
--- a/tangelo/linq/simulator.py
+++ b/tangelo/linq/simulator.py
@@ -340,6 +340,9 @@ class Simulator:
         if self._target == "qulacs" and not self.n_shots:
             import qulacs
 
+            # Note: This section previously used qulacs.quantum_operator.create_quantum_operator_from_openfermion_text but was changed
+            # due to a memory leak. We can re-evaluate the implementation if/when Issue #303 (https://github.com/qulacs/qulacs/issues/303)
+            # is fixed.
             operator = qulacs.Observable(n_qubits)
             for term, coef in qubit_operator.terms.items():
                 pauli_string = "".join(f" {op} {qu}" for qu, op in term)


### PR DESCRIPTION
There is a memory leak in the `qulacs` function `create_quantum_operator_from_openfermion_text`. This PR replaces that function with a different qulacs function. 

I opened an issue in qulacs. if they fix it and we can revert back to the old code.