### PR TITLE
Extended mixed state

### DIFF
--- a/tangelo/linq/simulator.py
+++ b/tangelo/linq/simulator.py
@@ -384,8 +384,9 @@ class Simulator:
 
     @staticmethod
     def marginal_frequencies(frequencies, indices, desired_measurement=None):
-        """Return the marginal frequencies on given indices. If desired_measurement
-        is given, frequencies on other indices are conditional on indices measurement being the desired measurement
+        """Return the marginal frequencies for indices. If desired_measurement
+        is given, frequencies returned for the other indices are conditional on the
+        measurement of the indices being the desired measurement.
 
         Args:
             frequencies (dict): The frequency dictionary to perform the marginal computation

--- a/tangelo/linq/simulator.py
+++ b/tangelo/linq/simulator.py
@@ -284,12 +284,12 @@ class Simulator:
             import qsharp
             qsharp.reload()
             from MyNamespace import EstimateFrequencies
-            frequencies_list = EstimateFrequencies.simulate(nQubits=source_circuit.width, nShots=self.n_shots)
+            frequencies_list = EstimateFrequencies.simulate(nQubits=source_circuit.width+num_meas, nShots=self.n_shots)
             print("Q# frequency estimation with {0} shots: \n {1}".format(self.n_shots, frequencies_list))
 
             # Convert Q# output to frequency dictionary, apply threshold
             frequencies = {bin(i).split('b')[-1]: frequencies_list[i] for i, freq in enumerate(frequencies_list)}
-            frequencies = {("0"*(source_circuit.width-len(k))+k)[::-1]: v for k, v in frequencies.items()
+            frequencies = {("0"*(num_meas+source_circuit.width-len(k))+k)[::-1]: v for k, v in frequencies.items()
                            if v > self.freq_threshold}
             return (frequencies, None)
 

--- a/tangelo/linq/simulator.py
+++ b/tangelo/linq/simulator.py
@@ -315,7 +315,6 @@ class Simulator:
 
         elif self._target == "cirq":
             import cirq
-            from cirq.transformers.measurement_transformers import dephase_measurements
 
             if (source_circuit.is_mixed_state or self._noise_model) and not save_mid_circuit_meas:
                 # Only DensityMatrixSimulator handles noise well, can use Simulator but it is slower
@@ -333,7 +332,7 @@ class Simulator:
                 translated_circuit = translator.translate_cirq(source_circuit, self._noise_model)
                 # cirq.dephase_measurements changes measurement gates to Krauss operators so simulators
                 # can be called once and density matrix sampled repeatedly.
-                translated_circuit = dephase_measurements(translated_circuit)
+                translated_circuit = cirq.dephase_measurements(translated_circuit)
                 sim = cirq_simulator.simulate(translated_circuit, initial_state=cirq_initial_statevector)
                 self._current_state = sim.final_density_matrix
                 indices = list(range(source_circuit.width))

--- a/tangelo/linq/simulator.py
+++ b/tangelo/linq/simulator.py
@@ -315,8 +315,6 @@ class Simulator:
 
             if (source_circuit.is_mixed_state or self._noise_model) and not save_mid_circuit_meas:
                 # Only DensityMatrixSimulator handles noise well, can use Simulator but it is slower
-                # ignore_measurement_results changes measurement gates to Krauss operators so simulators
-                # can be called once and density matrix sampled repeatedly.
                 cirq_simulator = cirq.DensityMatrixSimulator(dtype=np.complex128)
             elif save_mid_circuit_meas:
                 cirq_simulator = cirq.DensityMatrixSimulator(dtype=np.complex128) if self._noise_model else cirq.Simulator(dtype=np.complex128)
@@ -329,6 +327,8 @@ class Simulator:
             # Calculate final density matrix and sample from that for noisy simulation or simulating non-saved mixed states
             if (self._noise_model or source_circuit.is_mixed_state) and not save_mid_circuit_meas:
                 translated_circuit = translator.translate_cirq(source_circuit, self._noise_model)
+                # cirq.dephase_measurements changes measurement gates to Krauss operators so simulators
+                # can be called once and density matrix sampled repeatedly.
                 translated_circuit = dephase_measurements(translated_circuit)
                 sim = cirq_simulator.simulate(translated_circuit, initial_state=cirq_initial_statevector)
                 self._current_state = sim.final_density_matrix

--- a/tangelo/linq/tests/test_simulator.py
+++ b/tangelo/linq/tests/test_simulator.py
@@ -24,7 +24,7 @@ import numpy as np
 from openfermion.ops import QubitOperator
 from openfermion import load_operator, get_sparse_operator
 
-from tangelo.linq import Gate, Circuit, simulator, translator, Simulator
+from tangelo.linq import Gate, Circuit, translator, Simulator
 from tangelo.linq.gate import PARAMETERIZED_GATES
 from tangelo.helpers.utils import installed_simulator, installed_sv_simulator, installed_backends
 

--- a/tangelo/linq/tests/test_simulator.py
+++ b/tangelo/linq/tests/test_simulator.py
@@ -129,6 +129,39 @@ class TestSimulateAllBackends(unittest.TestCase):
             results[b], _ = sim.simulate(circuit_mixed)
             assert_freq_dict_almost_equal(results[b], reference_mixed, 1e-2)
 
+    def test_simulate_mixed_state_save_measures(self):
+        """ Test mid-circuit measurement (mixed-state simulation) for compatible/testable formats and backends.
+        Mixed-state do not have a statevector representation, as they are a statistical mixture of several statevectors.
+        Simulating individual shots is suitable.
+
+        Some simulators are NOT good at this, by design
+        """
+
+        results = dict()
+        for b in installed_simulator:
+            tstart = time.time()
+            sim = Simulator(target=b, n_shots=10 ** 3)
+            results[b], _ = sim.simulate(circuit_mixed, save_mid_circuit_meas=True)
+            tend = time.time()
+            print(b, tend-tstart)
+            assert_freq_dict_almost_equal(results[b], reference_mixed, 1e-1)
+
+    def test_simulate_mixed_state_desired_state(self):
+        """ Test mid-circuit measurement (mixed-state simulation) for compatible/testable formats and backends.
+        Mixed-state do not have a statevector representation, as they are a statistical mixture of several statevectors.
+        Simulating individual shots is suitable.
+
+        Some simulators are NOT good at this, by design
+        """
+
+        results = dict()
+        for b in installed_simulator:
+            tstart = time.time()
+            sim = Simulator(target=b, n_shots=10 ** 3)
+            results[b], _ = sim.simulate(circuit_mixed, desired_meas_result="0")
+            tend = time.time()
+            print(b, results[b], tend-tstart)
+
     def test_get_exp_value_mixed_state(self):
         """ Test expectation value for mixed-state simulation. Computation done by drawing individual shots.
         Some simulators are NOT good at this, by design (ProjectQ). """

--- a/tangelo/linq/tests/test_simulator.py
+++ b/tangelo/linq/tests/test_simulator.py
@@ -367,7 +367,7 @@ class TestSimulateStatevector(unittest.TestCase):
 
         simulator = Simulator(n_shots=10**4)
         sim_exp = simulator.get_expectation_value(qubit_operator, circuit_mixed, desired_meas_result="0")
-        self.assertAlmostEquals(exact_exp, sim_exp, delta=1.e-1)
+        self.assertAlmostEqual(exact_exp, sim_exp, delta=1.e-1)
 
     def test_get_exp_value_empty_circuit(self):
         """ If the circuit is empty and we have a non-zero number of qubits, frequencies just only show all-|0> state

--- a/tangelo/linq/tests/test_simulator_noisy.py
+++ b/tangelo/linq/tests/test_simulator_noisy.py
@@ -223,10 +223,10 @@ class TestSimulate(unittest.TestCase):
         s_nmm = Simulator(target="cirq", n_shots=10**4, noise_model=nmm)
         res_mixed, sv = s_nmm.simulate(circuit_mixed, desired_meas_result="0", return_statevector=True)
         assert_freq_dict_almost_equal(ref_mixed_0, res_mixed, 7.e-2)
-        exact_sv = np.array([[ 0.15403023+0.j, -0.0841471 -0.j,  0.        +0.j,  0.        -0.j],
-                             [-0.0841471 -0.j,  0.04596977+0.j,  0.        -0.j,  0.        +0.j],
-                             [ 0.        +0.j,  0.        -0.j,  0.61612092+0.j, -0.33658839-0.j],
-                             [ 0.        -0.j,  0.        +0.j, -0.33658839-0.j,  0.18387908+0.j]])
+        exact_sv = np.array([[ 0.15403023 + 0.j, -0.08414710 - 0.j,  0.00000000 + 0.j,  0.00000000 - 0.j],
+                             [-0.08414710 - 0.j,  0.04596977 + 0.j,  0.00000000 - 0.j,  0.00000000 + 0.j],
+                             [ 0.00000000 + 0.j,  0.00000000 - 0.j,  0.61612092 + 0.j, -0.33658839 - 0.j],
+                             [ 0.00000000 - 0.j,  0.00000000 + 0.j, -0.33658839 - 0.j,  0.18387908 + 0.j]])
         np.testing.assert_array_almost_equal(sv, exact_sv)
 
     def test_get_expectation_value_noisy(self):

--- a/tangelo/linq/translator/translate_cirq.py
+++ b/tangelo/linq/translator/translate_cirq.py
@@ -57,14 +57,13 @@ def get_cirq_gates():
     return GATE_CIRQ
 
 
-def translate_cirq(source_circuit, noise_model=None, label_measurements=False):
+def translate_cirq(source_circuit, noise_model=None):
     """Take in an abstract circuit, return an equivalent cirq QuantumCircuit
     instance.
 
     Args:
         source_circuit (Circuit): quantum circuit in the abstract format.
         noise_model (NoiseModel): The noise model to use
-        return_all_measurements (bool): Label all measurements in circuit
 
     Returns:
         cirq.Circuit: a corresponding cirq Circuit. Right now, the structure is
@@ -100,8 +99,9 @@ def translate_cirq(source_circuit, noise_model=None, label_measurements=False):
         elif gate.name in {"CNOT"}:
             target_circuit.append(GATE_CIRQ[gate.name](qubit_list[gate.control[0]], qubit_list[gate.target[0]]))
         elif gate.name in {"MEASURE"}:
-            key = str(measure_count) if label_measurements else None
+            key = str(measure_count)
             target_circuit.append(GATE_CIRQ[gate.name](qubit_list[gate.target[0]], key=key))
+            measure_count += 1
         elif gate.name in {"CRZ", "CRX", "CRY"}:
             next_gate = GATE_CIRQ[gate.name](gate.parameter).controlled(num_controls)
             target_circuit.append(next_gate(*control_list, qubit_list[gate.target[0]]))

--- a/tangelo/linq/translator/translate_cirq.py
+++ b/tangelo/linq/translator/translate_cirq.py
@@ -57,13 +57,16 @@ def get_cirq_gates():
     return GATE_CIRQ
 
 
-def translate_cirq(source_circuit, noise_model=None, label_measurements=False):
+def translate_cirq(source_circuit, noise_model=None, save_measurements=False):
     """Take in an abstract circuit, return an equivalent cirq QuantumCircuit
     instance.
 
     Args:
         source_circuit (Circuit): quantum circuit in the abstract format.
         noise_model (NoiseModel): The noise model to use
+        save_measurements (bool): If True, all measurements in the circuit are saved
+            with the key 'n' for the nth measurement in the Circuit. If False, no
+            measurements are saved.
 
     Returns:
         cirq.Circuit: a corresponding cirq Circuit. Right now, the structure is
@@ -99,7 +102,7 @@ def translate_cirq(source_circuit, noise_model=None, label_measurements=False):
         elif gate.name in {"CNOT"}:
             target_circuit.append(GATE_CIRQ[gate.name](qubit_list[gate.control[0]], qubit_list[gate.target[0]]))
         elif gate.name in {"MEASURE"}:
-            key = str(measure_count) if label_measurements else None
+            key = str(measure_count) if save_measurements else None
             target_circuit.append(GATE_CIRQ[gate.name](qubit_list[gate.target[0]], key=key))
             measure_count += 1
         elif gate.name in {"CRZ", "CRX", "CRY"}:

--- a/tangelo/linq/translator/translate_cirq.py
+++ b/tangelo/linq/translator/translate_cirq.py
@@ -57,7 +57,7 @@ def get_cirq_gates():
     return GATE_CIRQ
 
 
-def translate_cirq(source_circuit, noise_model=None):
+def translate_cirq(source_circuit, noise_model=None, label_measurements=False):
     """Take in an abstract circuit, return an equivalent cirq QuantumCircuit
     instance.
 
@@ -99,7 +99,7 @@ def translate_cirq(source_circuit, noise_model=None):
         elif gate.name in {"CNOT"}:
             target_circuit.append(GATE_CIRQ[gate.name](qubit_list[gate.control[0]], qubit_list[gate.target[0]]))
         elif gate.name in {"MEASURE"}:
-            key = str(measure_count)
+            key = str(measure_count) if label_measurements else None
             target_circuit.append(GATE_CIRQ[gate.name](qubit_list[gate.target[0]], key=key))
             measure_count += 1
         elif gate.name in {"CRZ", "CRX", "CRY"}:

--- a/tangelo/linq/translator/translate_qdk.py
+++ b/tangelo/linq/translator/translate_qdk.py
@@ -62,12 +62,15 @@ def translate_qsharp(source_circuit, operation="MyQsharpOperation"):
 
     GATE_QDK = get_qdk_gates()
 
+    n_meas = source_circuit._gate_counts.get("MEASURE", 0)
+    n_c = n_meas + source_circuit.width
+    measurement = 0
     # Prepare Q# operation header
     qsharp_string = ""
     qsharp_string += "@EntryPoint()\n"
     qsharp_string += f"operation {operation}() : Result[] {{\n"
 #    qsharp_string += "body (...) {\n\n"
-    qsharp_string += f"\tmutable c = new Result[{source_circuit.width}];\n"
+    qsharp_string += f"\tmutable c = new Result[{n_c}];\n"
     qsharp_string += f"\tusing (qreg = Qubit[{source_circuit.width}]) {{\n"
 
     # Generate Q# strings with the right syntax, order and values for the gate inputs
@@ -94,10 +97,12 @@ def translate_qsharp(source_circuit, operation="MyQsharpOperation"):
         elif gate.name in {"CSWAP"}:
             body_str += f"\t\tControlled {GATE_QDK[gate.name]}({control_string}, (qreg[{gate.target[0]}], qreg[{gate.target[1]}]));\n"
         elif gate.name in {"MEASURE"}:
-            body_str += f"\t\tset c w/= {gate.target[0]} <- {GATE_QDK[gate.name]}(qreg[{gate.target[0]}]);\n"
+            body_str += f"\t\tset c w/= {measurement} <- {GATE_QDK[gate.name]}(qreg[{gate.target[0]}]);\n"
+            measurement += 1
         else:
             raise ValueError(f"Gate '{gate.name}' not supported on backend qdk")
-    qsharp_string += body_str + "\n\t\treturn ForEach(MResetZ, qreg);\n"
+    return_str = f"\n\t\tfor index in 0 .. Length(qreg) - 1 {{\n\t\t\tset c w/= {n_meas} + index <- MResetZ(qreg[index]);\n\t\t}}\n"
+    qsharp_string += body_str + return_str + "\n\t\treturn c;\n"
     qsharp_string += "\t}\n"
 #    qsharp_string += "}\n adjoint auto;\n"
     qsharp_string += "}\n"

--- a/tangelo/linq/translator/translate_qdk.py
+++ b/tangelo/linq/translator/translate_qdk.py
@@ -54,7 +54,7 @@ def translate_qsharp(source_circuit, operation="MyQsharpOperation", label_measur
     Args:
         source_circuit: quantum circuit in the abstract format.
         operation (str), optional: name of the Q# operation.
-        label_measurements (bool), optional: return all mid-circuit measurement results. 
+        label_measurements (bool), optional: return all mid-circuit measurement results.
 
     Returns:
         str: The Q# code (operation + template). This needs to be written into a

--- a/tangelo/linq/translator/translate_qiskit.py
+++ b/tangelo/linq/translator/translate_qiskit.py
@@ -72,7 +72,10 @@ def translate_qiskit(source_circuit):
     import qiskit
 
     GATE_QISKIT = get_qiskit_gates()
-    target_circuit = qiskit.QuantumCircuit(source_circuit.width, source_circuit.width)
+    num_measures = source_circuit._gate_counts.get("MEASURE", 0) + source_circuit.width
+    target_circuit = qiskit.QuantumCircuit(source_circuit.width, num_measures)
+
+    measurement = 0
 
     # Maps the gate information properly. Different for each backend (order, values)
     for gate in source_circuit._gates:
@@ -94,7 +97,8 @@ def translate_qiskit(source_circuit):
         elif gate.name in {"XX"}:
             (GATE_QISKIT[gate.name])(target_circuit, gate.parameter, gate.target[0], gate.target[1])
         elif gate.name in {"MEASURE"}:
-            (GATE_QISKIT[gate.name])(target_circuit, gate.target[0], gate.target[0])
+            (GATE_QISKIT[gate.name])(target_circuit, gate.target[0], measurement)
+            measurement += 1
         else:
             raise ValueError(f"Gate '{gate.name}' not supported on backend qiskit")
     return target_circuit

--- a/tangelo/linq/translator/translate_qiskit.py
+++ b/tangelo/linq/translator/translate_qiskit.py
@@ -58,12 +58,13 @@ def get_qiskit_gates():
     return GATE_QISKIT
 
 
-def translate_qiskit(source_circuit):
+def translate_qiskit(source_circuit, label_measurements=False):
     """Take in an abstract circuit, return an equivalent qiskit QuantumCircuit
     instance
 
     Args:
-        source_circuit: quantum circuit in the abstract format.
+        source_circuit (Circuit): quantum circuit in the abstract format.
+        label_measurements (bool): Return mid circuit measurements
 
     Returns:
         qiskit.QuantumCircuit: the corresponding qiskit quantum circuit.
@@ -72,7 +73,8 @@ def translate_qiskit(source_circuit):
     import qiskit
 
     GATE_QISKIT = get_qiskit_gates()
-    num_measures = source_circuit._gate_counts.get("MEASURE", 0) + source_circuit.width
+    n_meas = source_circuit._gate_counts.get("MEASURE", 0) if label_measurements else 0
+    num_measures = n_meas + source_circuit.width
     target_circuit = qiskit.QuantumCircuit(source_circuit.width, num_measures)
 
     measurement = 0
@@ -98,7 +100,8 @@ def translate_qiskit(source_circuit):
             (GATE_QISKIT[gate.name])(target_circuit, gate.parameter, gate.target[0], gate.target[1])
         elif gate.name in {"MEASURE"}:
             (GATE_QISKIT[gate.name])(target_circuit, gate.target[0], measurement)
-            measurement += 1
+            if label_measurements:
+                measurement += 1
         else:
             raise ValueError(f"Gate '{gate.name}' not supported on backend qiskit")
     return target_circuit

--- a/tangelo/linq/translator/translate_qiskit.py
+++ b/tangelo/linq/translator/translate_qiskit.py
@@ -58,13 +58,14 @@ def get_qiskit_gates():
     return GATE_QISKIT
 
 
-def translate_qiskit(source_circuit, label_measurements=False):
+def translate_qiskit(source_circuit, save_measurements=False):
     """Take in an abstract circuit, return an equivalent qiskit QuantumCircuit
     instance
 
     Args:
         source_circuit (Circuit): quantum circuit in the abstract format.
-        label_measurements (bool): Return mid circuit measurements
+        save_measurements (bool): Return mid-circuit measurements in the order
+            they appear in the circuit in the classical registers
 
     Returns:
         qiskit.QuantumCircuit: the corresponding qiskit quantum circuit.
@@ -73,9 +74,9 @@ def translate_qiskit(source_circuit, label_measurements=False):
     import qiskit
 
     GATE_QISKIT = get_qiskit_gates()
-    n_meas = source_circuit._gate_counts.get("MEASURE", 0) if label_measurements else 0
-    num_measures = n_meas + source_circuit.width
-    target_circuit = qiskit.QuantumCircuit(source_circuit.width, num_measures)
+    n_meas = source_circuit._gate_counts.get("MEASURE", 0) if save_measurements else 0
+    n_measures = n_meas + source_circuit.width
+    target_circuit = qiskit.QuantumCircuit(source_circuit.width, n_measures)
 
     measurement = 0
 
@@ -100,7 +101,7 @@ def translate_qiskit(source_circuit, label_measurements=False):
             (GATE_QISKIT[gate.name])(target_circuit, gate.parameter, gate.target[0], gate.target[1])
         elif gate.name in {"MEASURE"}:
             (GATE_QISKIT[gate.name])(target_circuit, gate.target[0], measurement)
-            if label_measurements:
+            if save_measurements:
                 measurement += 1
         else:
             raise ValueError(f"Gate '{gate.name}' not supported on backend qiskit")

--- a/tangelo/linq/translator/translate_qulacs.py
+++ b/tangelo/linq/translator/translate_qulacs.py
@@ -79,6 +79,8 @@ def translate_qulacs(source_circuit, noise_model=None):
     GATE_QULACS = get_qulacs_gates()
     target_circuit = qulacs.QuantumCircuit(source_circuit.width)
 
+    measure_count = 0
+
     # Maps the gate information properly. Different for each backend (order, values)
     for gate in source_circuit._gates:
         if gate.name in {"H", "X", "Y", "Z", "S", "T"}:
@@ -121,8 +123,9 @@ def translate_qulacs(source_circuit, noise_model=None):
         elif gate.name in {"CNOT"}:
             (GATE_QULACS[gate.name])(target_circuit, gate.control[0], gate.target[0])
         elif gate.name in {"MEASURE"}:
-            gate = (GATE_QULACS[gate.name])(gate.target[0], gate.target[0])
+            gate = (GATE_QULACS[gate.name])(gate.target[0], measure_count)
             target_circuit.add_gate(gate)
+            measure_count += 1
         else:
             raise ValueError(f"Gate '{gate.name}' not supported on backend qulacs")
 

--- a/tangelo/linq/translator/translate_qulacs.py
+++ b/tangelo/linq/translator/translate_qulacs.py
@@ -123,8 +123,8 @@ def translate_qulacs(source_circuit, noise_model=None):
         elif gate.name in {"CNOT"}:
             (GATE_QULACS[gate.name])(target_circuit, gate.control[0], gate.target[0])
         elif gate.name in {"MEASURE"}:
-            gate = (GATE_QULACS[gate.name])(gate.target[0], measure_count)
-            target_circuit.add_gate(gate)
+            m_gate = (GATE_QULACS[gate.name])(gate.target[0], measure_count)
+            target_circuit.add_gate(m_gate)
             measure_count += 1
         else:
             raise ValueError(f"Gate '{gate.name}' not supported on backend qulacs")

--- a/tangelo/linq/translator/translate_qulacs.py
+++ b/tangelo/linq/translator/translate_qulacs.py
@@ -58,16 +58,19 @@ def get_qulacs_gates():
     return GATE_QULACS
 
 
-def translate_qulacs(source_circuit, noise_model=None):
+def translate_qulacs(source_circuit, noise_model=None, save_measurements=False):
     """Take in an abstract circuit, return an equivalent qulacs QuantumCircuit
     instance. If provided with a noise model, will add noisy gates at
     translation. Not very useful to look at, as qulacs does not provide much
     information about the noisy gates added when printing the "noisy circuit".
 
     Args:
-        source_circuit: quantum circuit in the abstract format.
-        noise_model: A NoiseModel object from this package, located in the
+        source_circuit (Circuit): quantum circuit in the abstract format.
+        noise_model (NoiseModel): A NoiseModel object from this package, located in the
             noisy_simulation subpackage.
+        save_measurements (bool): If True, each nth measurement in the circuit is saved in
+            the nth classical register. Otherwise each measurement overwrites
+            the first classical register.
 
     Returns:
         qulacs.QuantumCircuit: the corresponding qulacs quantum circuit.
@@ -125,7 +128,8 @@ def translate_qulacs(source_circuit, noise_model=None):
         elif gate.name in {"MEASURE"}:
             m_gate = (GATE_QULACS[gate.name])(gate.target[0], measure_count)
             target_circuit.add_gate(m_gate)
-            measure_count += 1
+            if save_measurements:
+                measure_count += 1
         else:
             raise ValueError(f"Gate '{gate.name}' not supported on backend qulacs")
 


### PR DESCRIPTION
Save mid-circuit measurements for cirq, qiskit, qdk, and qulacs.
desired_meas_result permits users to select which measurement values they want to post-select. The frequency dictionary and statevector(possibly density matrix for cirq) returned corresponds to the requested mid-circuit measurement.