### PR TITLE
Fix the need for spin with a qubit operator + pool of fermion operators

### DIFF
--- a/tangelo/algorithms/variational/adapt_vqe_solver.py
+++ b/tangelo/algorithms/variational/adapt_vqe_solver.py
@@ -145,14 +145,12 @@ class ADAPTSolver:
             self.spin = self.molecule.spin
 
             # Compute qubit hamiltonian for the input molecular system
-            qubit_op = fermion_to_qubit_mapping(fermion_operator=self.molecule.fermionic_hamiltonian,
-                                                mapping=self.qubit_mapping,
-                                                n_spinorbitals=self.n_spinorbitals,
-                                                n_electrons=self.n_electrons,
-                                                up_then_down=self.up_then_down,
-                                                spin=self.spin)
-
-            self.qubit_hamiltonian = qubit_op
+            self.qubit_hamiltonian = fermion_to_qubit_mapping(fermion_operator=self.molecule.fermionic_hamiltonian,
+                                                              mapping=self.qubit_mapping,
+                                                              n_spinorbitals=self.n_spinorbitals,
+                                                              n_electrons=self.n_electrons,
+                                                              up_then_down=self.up_then_down,
+                                                              spin=self.spin)
 
         # Build / set ansatz circuit.
         ansatz_options = {"mapping": self.qubit_mapping, "up_then_down": self.up_then_down,
@@ -215,7 +213,7 @@ class ADAPTSolver:
 
         # Getting commutators to compute gradients:
         # \frac{\partial E}{\partial \theta_n} = \langle \psi | [\hat{H}, A_n] | \psi \rangle
-        self.pool_commutators = [commutator(self.qubit_hamiltonian.to_qubitoperator(), element) for element in self.pool_operators]
+        self.pool_commutators = [commutator(self.qubit_hamiltonian, element) for element in self.pool_operators]
 
     def simulate(self):
         """Performs the ADAPT cycles. Each iteration, a VQE minimization is

--- a/tangelo/algorithms/variational/adapt_vqe_solver.py
+++ b/tangelo/algorithms/variational/adapt_vqe_solver.py
@@ -152,7 +152,7 @@ class ADAPTSolver:
                                                 up_then_down=self.up_then_down,
                                                 spin=self.spin)
 
-            self.qubit_hamiltonian = qubitop_to_qubitham(qubit_op, self.qubit_mapping, self.up_then_down)
+            self.qubit_hamiltonian = qubit_op
 
         # Build / set ansatz circuit.
         ansatz_options = {"mapping": self.qubit_mapping, "up_then_down": self.up_then_down,
@@ -215,7 +215,7 @@ class ADAPTSolver:
 
         # Getting commutators to compute gradients:
         # \frac{\partial E}{\partial \theta_n} = \langle \psi | [\hat{H}, A_n] | \psi \rangle
-        self.pool_commutators = [commutator(self.qubit_hamiltonian, element) for element in self.pool_operators]
+        self.pool_commutators = [commutator(self.qubit_hamiltonian.to_qubitoperator(), element) for element in self.pool_operators]
 
     def simulate(self):
         """Performs the ADAPT cycles. Each iteration, a VQE minimization is

--- a/tangelo/algorithms/variational/adapt_vqe_solver.py
+++ b/tangelo/algorithms/variational/adapt_vqe_solver.py
@@ -189,7 +189,9 @@ class ADAPTSolver:
 
         # Only a qubit operator is provided with a FermionOperator pool.
         if not (self.n_spinorbitals and self.n_electrons and self.spin is not None):
-            raise ValueError("Expecting the number of spin-orbitals (n_spinorbitals), the number of electrons (n_electrons) and the spin (spin) with a qubit_hamiltonian when working with a pool of fermion operators.")
+            raise ValueError("Expecting the number of spin-orbitals (n_spinorbitals), "
+                "the number of electrons (n_electrons) and the spin (spin) with "
+                "a qubit_hamiltonian when working with a pool of fermion operators.")
 
         if isinstance(pool_list[0], QubitOperator):
             self.pool_type = 'qubit'


### PR DESCRIPTION
`spin` was not defined with a `qubit_hamiltonian`, but it is needed to convert the pool of fermion operators to qubit operators.