### PR TITLE
Fix scbk reference state

### DIFF
--- a/tangelo/toolboxes/qubit_mappings/statevector_mapping.py
+++ b/tangelo/toolboxes/qubit_mappings/statevector_mapping.py
@@ -93,14 +93,19 @@ def do_scbk_transform(vector, n_spinorbitals):
     """
 
     fenwick_tree = FenwickTree(n_spinorbitals)
+    # Generate QubitOperator that represents excitation through Majorana mode (a_i^+ - a_) for each occupied orbital
     qu_op = QubitOperator((), 1)
     for ind, oc in enumerate(vector):
         if oc == 1:
             qu_op *= (_transform_ladder_operator((ind, 1), fenwick_tree) - _transform_ladder_operator((ind, 0), fenwick_tree))
+
+    # Include all qubits that have Pauli operator X or Y acting on them in new occupation vector.
     vector_bk = np.zeros(n_spinorbitals)
     active_qus = [i for i, j in next(iter(qu_op.terms)) if j != "Z"]
     for q in active_qus:
         vector_bk[q] = 1
+
+    # Delete n_spinorbital and last qubit as is done for the scBK transform.
     vector_bk = np.delete(vector_bk, n_spinorbitals-1)
     vector_scbk = np.delete(vector_bk, n_spinorbitals//2-1)
     return vector_scbk

--- a/tangelo/toolboxes/qubit_mappings/statevector_mapping.py
+++ b/tangelo/toolboxes/qubit_mappings/statevector_mapping.py
@@ -45,6 +45,7 @@ def get_vector(n_spinorbitals, n_electrons, mapping, up_then_down=False, spin=No
             (Jiang Kalev Mruczkiewicz Neven)
         up_then_down (boolean): if True, all up, then all down, if False,
             alternating spin up/down.
+         spin (int): 2*S = n_alpha - n_beta.
 
     Returns:
         numpy array of int: binary integer array indicating occupation of each

--- a/tangelo/toolboxes/qubit_mappings/statevector_mapping.py
+++ b/tangelo/toolboxes/qubit_mappings/statevector_mapping.py
@@ -87,6 +87,7 @@ def do_scbk_transform(vector, n_spinorbitals):
 
     Args:
         vector (numpy array of int): fermion occupation vector.
+        n_spinorbitals (int): number of qubits in register.
 
     Returns:
         numpy array of int: qubit-encoded occupation vector.

--- a/tangelo/toolboxes/qubit_mappings/tests/test_statevector_mapping.py
+++ b/tangelo/toolboxes/qubit_mappings/tests/test_statevector_mapping.py
@@ -16,7 +16,10 @@
 fermionic occupation of reference state into qubit representation.
 """
 
+
 import unittest
+from itertools import combinations
+
 import numpy as np
 
 from tangelo.toolboxes.qubit_mappings.statevector_mapping import get_vector, vector_to_circuit
@@ -26,6 +29,9 @@ from tangelo.toolboxes.qubit_mappings.mapping_transform import fermion_to_qubit_
 from tangelo.linq import Simulator
 
 sim = Simulator()
+spin_ind_transforms = ["BK", "JW", "JKMN"]
+spin_dep_transforms = ["SCBK"]
+all_transforms = spin_ind_transforms + spin_dep_transforms
 
 
 class TestVector(unittest.TestCase):
@@ -76,126 +82,80 @@ class TestVector(unittest.TestCase):
         for an even number of electrons and various spins. Molecules tested are H4, and H2O
         with frozen_orbitals=[0, 7] which failed previously for scbk"""
         mols = [mol_H4_sto3g, SecondQuantizedMolecule(xyz_H2O, 0, 0, "sto-3g", frozen_orbitals=[0, 7])]
+        circuits = dict()
+        qu_ops = dict()
         for mol in mols:
             ferm_op = mol.fermionic_hamiltonian
-            qu_op_bk = fermion_to_qubit_mapping(ferm_op,
-                                                "BK",
-                                                mol.n_active_sos,
-                                                mol.n_active_electrons,
-                                                up_then_down=True)
-            qu_op_jw = fermion_to_qubit_mapping(ferm_op,
-                                                "JW",
-                                                mol.n_active_sos,
-                                                mol.n_active_electrons,
-                                                up_then_down=True)
-            qu_op_jkmn = fermion_to_qubit_mapping(ferm_op,
-                                                  "JKMN",
-                                                  mol.n_active_sos,
-                                                  mol.n_active_electrons,
-                                                  up_then_down=True)
+            qu_ops = dict()
+            for transform in spin_ind_transforms:
+                qu_ops[transform] = fermion_to_qubit_mapping(ferm_op,
+                                                             transform,
+                                                             mol.n_active_sos,
+                                                             mol.n_active_electrons,
+                                                             up_then_down=True)
 
             # Test for spin 0, 2, and 4
             for spin in range(3):
-                vector_bk = get_vector(mol.n_active_sos,
-                                       mol.n_active_electrons,
-                                       mapping="BK",
-                                       up_then_down=True,
-                                       spin=spin*2)
-                vector_scbk = get_vector(mol.n_active_sos,
-                                         mol.n_active_electrons,
-                                         mapping="SCBK",
-                                         up_then_down=True,
-                                         spin=spin*2)
-                vector_jw = get_vector(mol.n_active_sos,
-                                       mol.n_active_electrons,
-                                       mapping="JW",
-                                       up_then_down=True,
-                                       spin=spin*2)
-                vector_jkmn = get_vector(mol.n_active_sos,
-                                         mol.n_active_electrons,
-                                         mapping="JKMN",
-                                         up_then_down=True,
-                                         spin=spin*2)
-                circuit_bk = vector_to_circuit(vector_bk)
-                circuit_scbk = vector_to_circuit(vector_scbk)
-                circuit_jw = vector_to_circuit(vector_jw)
-                circuit_jkmn = vector_to_circuit(vector_jkmn)
+                # Get circuits for transforms not dependant on spin
+                for transform in all_transforms:
+                    vector = get_vector(mol.n_active_sos,
+                                        mol.n_active_electrons,
+                                        mapping=transform,
+                                        up_then_down=True,
+                                        spin=spin*2)
+                    circuits[transform] = vector_to_circuit(vector)
 
-                qu_op_scbk = fermion_to_qubit_mapping(ferm_op,
-                                                      'SCBK',
-                                                      mol.n_active_sos,
-                                                      mol.n_active_electrons,
-                                                      up_then_down=True,
-                                                      spin=spin*2)
+                for transform in spin_dep_transforms:
+                    qu_ops[transform] = fermion_to_qubit_mapping(ferm_op,
+                                                                 'SCBK',
+                                                                 mol.n_active_sos,
+                                                                 mol.n_active_electrons,
+                                                                 up_then_down=True,
+                                                                 spin=spin*2)
 
-                e_bk = sim.get_expectation_value(qu_op_bk, circuit_bk)
-                e_scbk = sim.get_expectation_value(qu_op_scbk, circuit_scbk)
-                e_jw = sim.get_expectation_value(qu_op_jw, circuit_jw)
-                e_jkmn = sim.get_expectation_value(qu_op_jkmn, circuit_jkmn)
-                self.assertAlmostEqual(e_bk, e_jw, places=7, msg=f"Failed for bk vs jw for spin={spin}")
-                self.assertAlmostEqual(e_jw, e_scbk, places=7, msg=f"Failed for jw vs scbk for spin={spin}")
-                self.assertAlmostEqual(e_scbk, e_jkmn, places=7, msg=f"Failed for jkmn vs scbk for spin={spin}")
+                energies = dict()
+                for transform in all_transforms:
+                    energies[transform] = sim.get_expectation_value(qu_ops[transform], circuits[transform])
+
+                for t1, t2 in combinations(all_transforms, 2):
+                    self.assertAlmostEqual(energies[t1], energies[t2], places=7, msg=f"Failed for {t1} vs {t2} for spin={spin*2}")
 
     def test_all_same_energy_mol_H4_cation_sto3g(self):
         """Check that all mappings return statevectors that have the same energy expectation
         for an odd number of electrons and various spins"""
         ferm_op = mol_H4_cation_sto3g.fermionic_hamiltonian
-        qu_op_bk = fermion_to_qubit_mapping(ferm_op,
-                                            "BK",
-                                            mol_H4_cation_sto3g.n_active_sos,
-                                            mol_H4_cation_sto3g.n_active_electrons,
-                                            up_then_down=True)
-        qu_op_jw = fermion_to_qubit_mapping(ferm_op,
-                                            "JW",
-                                            mol_H4_cation_sto3g.n_active_sos,
-                                            mol_H4_cation_sto3g.n_active_electrons,
-                                            up_then_down=True)
-        qu_op_jkmn = fermion_to_qubit_mapping(ferm_op,
-                                              "JKMN",
-                                              mol_H4_cation_sto3g.n_active_sos,
-                                              mol_H4_cation_sto3g.n_active_electrons,
-                                              up_then_down=True)
+        circuits = dict()
+        qu_ops = dict()
+        for transform in spin_ind_transforms:
+            qu_ops[transform] = fermion_to_qubit_mapping(ferm_op,
+                                                         transform,
+                                                         mol_H4_cation_sto3g.n_active_sos,
+                                                         mol_H4_cation_sto3g.n_active_electrons,
+                                                         up_then_down=True)
+
         # Test for spin 1 and 3
         for spin in range(2):
-            vector_bk = get_vector(mol_H4_cation_sto3g.n_active_sos,
-                                   mol_H4_cation_sto3g.n_active_electrons,
-                                   mapping="BK",
-                                   up_then_down=True,
-                                   spin=spin*2+1)
-            vector_scbk = get_vector(mol_H4_cation_sto3g.n_active_sos,
-                                     mol_H4_cation_sto3g.n_active_electrons,
-                                     mapping="SCBK",
-                                     up_then_down=True,
-                                     spin=spin*2+1)
-            vector_jw = get_vector(mol_H4_cation_sto3g.n_active_sos,
-                                   mol_H4_cation_sto3g.n_active_electrons,
-                                   mapping="JW",
-                                   up_then_down=True,
-                                   spin=spin*2+1)
-            vector_jkmn = get_vector(mol_H4_cation_sto3g.n_active_sos,
-                                     mol_H4_cation_sto3g.n_active_electrons,
-                                     mapping="JKMN",
-                                     up_then_down=True,
-                                     spin=spin*2+1)
-            circuit_bk = vector_to_circuit(vector_bk)
-            circuit_scbk = vector_to_circuit(vector_scbk)
-            circuit_jw = vector_to_circuit(vector_jw)
-            circuit_jkmn = vector_to_circuit(vector_jkmn)
+            for transform in all_transforms:
+                vector = get_vector(mol_H4_cation_sto3g.n_active_sos,
+                                    mol_H4_cation_sto3g.n_active_electrons,
+                                    mapping=transform,
+                                    up_then_down=True,
+                                    spin=spin*2+1)
+                circuits[transform] = vector_to_circuit(vector)
+            for transform in spin_dep_transforms:
+                qu_ops[transform] = fermion_to_qubit_mapping(ferm_op,
+                                                             transform,
+                                                             mol_H4_cation_sto3g.n_active_sos,
+                                                             mol_H4_cation_sto3g.n_active_electrons,
+                                                             up_then_down=True,
+                                                             spin=spin*2+1)
 
-            qu_op_scbk = fermion_to_qubit_mapping(ferm_op,
-                                                  'SCBK',
-                                                  mol_H4_cation_sto3g.n_active_sos,
-                                                  mol_H4_cation_sto3g.n_active_electrons,
-                                                  up_then_down=True,
-                                                  spin=spin*2+1)
+            energies = dict()
+            for transform in all_transforms:
+                energies[transform] = sim.get_expectation_value(qu_ops[transform], circuits[transform])
 
-            e_bk = sim.get_expectation_value(qu_op_bk, circuit_bk)
-            e_scbk = sim.get_expectation_value(qu_op_scbk, circuit_scbk)
-            e_jw = sim.get_expectation_value(qu_op_jw, circuit_jw)
-            e_jkmn = sim.get_expectation_value(qu_op_jkmn, circuit_jkmn)
-            self.assertAlmostEqual(e_bk, e_jw, places=7, msg=f"Failed for bk vs jw for spin={spin}")
-            self.assertAlmostEqual(e_jw, e_scbk, places=7, msg=f"Failed for jw vs scbk for spin={spin}")
-            self.assertAlmostEqual(e_scbk, e_jkmn, places=7, msg=f"Failed for scbk vs jkmn for spin={spin}")
+            for t1, t2 in combinations(all_transforms, 2):
+                self.assertAlmostEqual(energies[t1], energies[t2], places=7, msg=f"Failed for {t1} vs {t2} for spin={spin*2}")
 
 
 if __name__ == "__main__":

--- a/tangelo/toolboxes/qubit_mappings/tests/test_statevector_mapping.py
+++ b/tangelo/toolboxes/qubit_mappings/tests/test_statevector_mapping.py
@@ -73,8 +73,8 @@ class TestVector(unittest.TestCase):
 
     def test_all_same_energy_mol_H4_sto3g_and_mol_H2O_sto3g(self):
         """Check that all mappings return statevectors that have the same energy expectation
-        for an even number of electrons and various spins. H2O with frozen_orbitals=[0, 7]
-        failed previously for scbk"""
+        for an even number of electrons and various spins. Molecules tested are H4, and H2O
+        with frozen_orbitals=[0, 7] which failed previously for scbk"""
         mols = [mol_H4_sto3g, SecondQuantizedMolecule(xyz_H2O, 0, 0, "sto-3g", frozen_orbitals=[0, 7])]
         for mol in mols:
             ferm_op = mol.fermionic_hamiltonian


### PR DESCRIPTION
There are two Bravyi-Kitaev transformations that are different if the number of qubits is not a power of 2. The current implementation used `bravyi_kitaev` for the reference state and `bravyi_kitaev_tree` for the SCBK mapping causing issues in certain instances. The example I came across was 
`mol = SecondQuantizedMolecule(xyz_H2O, 0, 0, "sto-3g", frozen_orbitals=[0, 7])`
which is now tested and passes.