### PR TITLE
Added restrictions for the frozen orbitals + FCISolver active space selection

### DIFF
--- a/tangelo/algorithms/classical/fci_solver.py
+++ b/tangelo/algorithms/classical/fci_solver.py
@@ -48,14 +48,14 @@ class FCISolver(ElectronicStructureSolver):
         # Need to use a CAS method if frozen orbitals are defined
         if molecule.frozen_mos is not None:
             # Generate CAS space with given frozen_mos, then use pyscf functionality to
-            # obtain effective Hamiltonian with frozen orbtials excluded from the CI space.
+            # obtain effective Hamiltonian with frozen orbitals excluded from the CI space.
             self.cas = True
             self.cassolver = mcscf.CASSCF(molecule.mean_field,
                                           molecule.n_active_mos,
-                                          (self.n_alpha, self.n_beta),
-                                          frozen=molecule.frozen_orbitals)
-            self.h1e_cas, self.ecore = self.cassolver.get_h1eff()
-            self.h2e_cas = self.cassolver.get_h2eff()
+                                          (self.n_alpha, self.n_beta))
+            mos = self.cassolver.sort_mo([i+1 for i in molecule.active_mos])
+            self.h1e_cas, self.ecore = self.cassolver.get_h1eff(mos)
+            self.h2e_cas = self.cassolver.get_h2eff(mos)
             # Initialize the FCI solver that will use the effective Hamiltonian generated from CAS
             self.cisolver = fci.direct_spin1.FCI()
         else:

--- a/tangelo/algorithms/variational/adapt_vqe_solver.py
+++ b/tangelo/algorithms/variational/adapt_vqe_solver.py
@@ -167,7 +167,7 @@ class ADAPTSolver:
                             }
 
         self.vqe_solver = VQESolver(self.vqe_options)
-        self.vqe_solver.build(check_var_circuit=False)
+        self.vqe_solver.build()
 
         # If applicable, give vqe_solver access to molecule object
         if self.molecule:

--- a/tangelo/algorithms/variational/adapt_vqe_solver.py
+++ b/tangelo/algorithms/variational/adapt_vqe_solver.py
@@ -78,7 +78,6 @@ class ADAPTSolver:
                            "tol": 1e-3, "max_cycles": 15,
                            "pool": uccgsd_pool,
                            "pool_args": None,
-                           "frozen_orbitals": "frozen_core",
                            "qubit_mapping": "jw",
                            "qubit_hamiltonian": None,
                            "up_then_down": False,

--- a/tangelo/algorithms/variational/adapt_vqe_solver.py
+++ b/tangelo/algorithms/variational/adapt_vqe_solver.py
@@ -167,7 +167,7 @@ class ADAPTSolver:
                             }
 
         self.vqe_solver = VQESolver(self.vqe_options)
-        self.vqe_solver.build()
+        self.vqe_solver.build(check_var_circuit=False)
 
         # If applicable, give vqe_solver access to molecule object
         if self.molecule:

--- a/tangelo/algorithms/variational/vqe_solver.py
+++ b/tangelo/algorithms/variational/vqe_solver.py
@@ -162,9 +162,13 @@ class VQESolver:
         self.optimal_var_params = None
         self.builtin_ansatze = set(BuiltInAnsatze)
 
-    def build(self):
+    def build(self, check_var_circuit=True):
         """Build the underlying objects required to run the VQE algorithm
         afterwards.
+
+        Args:
+            check_var_circuit (bool): Check or not if the circuit has at least
+                one variational parameter.
         """
 
         if isinstance(self.ansatz, Circuit):
@@ -256,7 +260,7 @@ class VQESolver:
         self.initial_var_params = self.ansatz.set_var_params(self.initial_var_params)
         self.ansatz.build_circuit()
 
-        if self.get_resources()["circuit_var_gates"] == 0:
+        if check_var_circuit and self.get_resources()["circuit_var_gates"] == 0:
             raise RuntimeError("No variational parameter in the circuit.")
 
         # Quantum circuit simulation backend options

--- a/tangelo/algorithms/variational/vqe_solver.py
+++ b/tangelo/algorithms/variational/vqe_solver.py
@@ -256,6 +256,9 @@ class VQESolver:
         self.initial_var_params = self.ansatz.set_var_params(self.initial_var_params)
         self.ansatz.build_circuit()
 
+        if self.get_resources()["circuit_var_gates"] == 0:
+            raise RuntimeError("No variational parameter in the circuit.")
+
         # Quantum circuit simulation backend options
         t = self.backend_options.get("target", self.default_backend_options["target"])
         ns = self.backend_options.get("n_shots", self.default_backend_options["n_shots"])

--- a/tangelo/algorithms/variational/vqe_solver.py
+++ b/tangelo/algorithms/variational/vqe_solver.py
@@ -256,8 +256,8 @@ class VQESolver:
         self.initial_var_params = self.ansatz.set_var_params(self.initial_var_params)
         self.ansatz.build_circuit()
 
-        if self.get_resources()["circuit_var_gates"] == 0:
-            raise RuntimeError("No variational parameter in the circuit.")
+        if self.get_resources()["circuit_var_gates"] == 0 and self.verbose:
+            warnings.warn("No variational parameter in the circuit.", RuntimeWarning)
 
         # Quantum circuit simulation backend options
         t = self.backend_options.get("target", self.default_backend_options["target"])
@@ -271,6 +271,10 @@ class VQESolver:
         """
         if not (self.ansatz and self.backend):
             raise RuntimeError("No ansatz circuit or hardware backend built. Have you called VQESolver.build ?")
+
+        if self.get_resources()["circuit_var_gates"] == 0:
+            raise RuntimeError("No variational parameter in the circuit.")
+
         optimal_energy, optimal_var_params = self.optimizer(self.energy_estimation, self.initial_var_params)
 
         self.optimal_var_params = optimal_var_params

--- a/tangelo/algorithms/variational/vqe_solver.py
+++ b/tangelo/algorithms/variational/vqe_solver.py
@@ -162,13 +162,9 @@ class VQESolver:
         self.optimal_var_params = None
         self.builtin_ansatze = set(BuiltInAnsatze)
 
-    def build(self, check_var_circuit=True):
+    def build(self):
         """Build the underlying objects required to run the VQE algorithm
         afterwards.
-
-        Args:
-            check_var_circuit (bool): Check or not if the circuit has at least
-                one variational parameter.
         """
 
         if isinstance(self.ansatz, Circuit):
@@ -260,7 +256,7 @@ class VQESolver:
         self.initial_var_params = self.ansatz.set_var_params(self.initial_var_params)
         self.ansatz.build_circuit()
 
-        if check_var_circuit and self.get_resources()["circuit_var_gates"] == 0:
+        if self.get_resources()["circuit_var_gates"] == 0:
             raise RuntimeError("No variational parameter in the circuit.")
 
         # Quantum circuit simulation backend options

--- a/tangelo/algorithms/variational/vqe_solver.py
+++ b/tangelo/algorithms/variational/vqe_solver.py
@@ -256,8 +256,8 @@ class VQESolver:
         self.initial_var_params = self.ansatz.set_var_params(self.initial_var_params)
         self.ansatz.build_circuit()
 
-        if self.get_resources()["circuit_var_gates"] == 0 and self.verbose:
-            warnings.warn("No variational parameter in the circuit.", RuntimeWarning)
+        if len(self.ansatz.circuit._variational_gates) == 0:
+            warnings.warn("No variational gate found in the circuit.", RuntimeWarning)
 
         # Quantum circuit simulation backend options
         t = self.backend_options.get("target", self.default_backend_options["target"])
@@ -272,8 +272,8 @@ class VQESolver:
         if not (self.ansatz and self.backend):
             raise RuntimeError("No ansatz circuit or hardware backend built. Have you called VQESolver.build ?")
 
-        if self.get_resources()["circuit_var_gates"] == 0:
-            raise RuntimeError("No variational parameter in the circuit.")
+        if len(self.ansatz.circuit._variational_gates) == 0:
+            raise RuntimeError("No variational gate found in the circuit.")
 
         optimal_energy, optimal_var_params = self.optimizer(self.energy_estimation, self.initial_var_params)
 

--- a/tangelo/toolboxes/molecular_computation/molecule.py
+++ b/tangelo/toolboxes/molecular_computation/molecule.py
@@ -269,6 +269,15 @@ class SecondQuantizedMolecule(Molecule):
         """
         return self.active_occupied + self.active_virtual
 
+    @property
+    def active_spin(self):
+        """This property returns the spin of the active space.
+
+        Returns:
+            int: n_alpha - n_beta electrons of the active occupied orbital space.
+        """
+        return sum([self.mo_occ[i] == 1 for i in self.active_occupied])
+
     def _compute_mean_field(self):
         """Computes the mean-field for the molecule. It supports open-shell
         mean-field calculation through openfermionpyscf. Depending on the
@@ -382,6 +391,9 @@ class SecondQuantizedMolecule(Molecule):
         """This method recomputes frozen orbitals with the provided input."""
 
         list_of_active_frozen = self._convert_frozen_orbitals(frozen_orbitals)
+
+        if any([self.mo_occ[i] == 1 for i in list_of_active_frozen[1]]):
+            raise NotImplementedError("Freezing half-filled orbitals is not implemented yet.")
 
         if inplace:
             self.frozen_orbitals = frozen_orbitals

--- a/tangelo/toolboxes/qubit_mappings/mapping_transform.py
+++ b/tangelo/toolboxes/qubit_mappings/mapping_transform.py
@@ -103,6 +103,9 @@ def fermion_to_qubit_mapping(fermion_operator, mapping, n_spinorbitals=None, n_e
     if mapping.upper() not in available_mappings:
         raise ValueError(f"Invalid mapping selection. Select from: {available_mappings}")
 
+    if mapping.upper in {"BK", "SCBK", "JKMN"} and n_spinorbitals is None:
+        raise ValueError(f"{mapping.upper()} requires n_spinorbitals to be set.")
+
     if up_then_down:
         if n_spinorbitals is None:
             raise ValueError("The number of spin-orbitals is required to execute basis re-ordering.")
@@ -111,12 +114,8 @@ def fermion_to_qubit_mapping(fermion_operator, mapping, n_spinorbitals=None, n_e
     if mapping.upper() == "JW":
         qubit_operator = jordan_wigner(fermion_operator)
     elif mapping.upper() == "BK":
-        if n_spinorbitals is None:
-            raise ValueError("Bravyi Kitaev requires specification of number of spin-orbitals.")
         qubit_operator = bravyi_kitaev(fermion_operator, n_qubits=n_spinorbitals)
     elif mapping.upper() == "SCBK":
-        if n_spinorbitals is None:
-            raise ValueError("Symmetry-conserving Bravyi Kitaev requires specification of number of spin-orbitals.")
         if n_electrons is None:
             raise ValueError("Symmetry-conserving Bravyi Kitaev requires specification of number of electrons.")
 
@@ -126,8 +125,6 @@ def fermion_to_qubit_mapping(fermion_operator, mapping, n_spinorbitals=None, n_e
                                                            up_then_down=up_then_down,
                                                            spin=spin)
     elif mapping.upper() == "JKMN":
-        if n_spinorbitals is None:
-            raise ValueError("JKMN mapping requires specification of number of spin-orbitals.")
         qubit_operator = jkmn(fermion_operator, n_qubits=n_spinorbitals)
 
     converted_qubit_op = QubitOperator()

--- a/tangelo/toolboxes/qubit_mappings/mapping_transform.py
+++ b/tangelo/toolboxes/qubit_mappings/mapping_transform.py
@@ -112,11 +112,11 @@ def fermion_to_qubit_mapping(fermion_operator, mapping, n_spinorbitals=None, n_e
         qubit_operator = jordan_wigner(fermion_operator)
     elif mapping.upper() == "BK":
         if n_spinorbitals is None:
-            raise ValueError("Bravyi Kitaev requires specification of number of qubits.")
+            raise ValueError("Bravyi Kitaev requires specification of number of spin-orbitals.")
         qubit_operator = bravyi_kitaev(fermion_operator, n_qubits=n_spinorbitals)
     elif mapping.upper() == "SCBK":
         if n_spinorbitals is None:
-            raise ValueError("Symmetry-conserving Bravyi Kitaev requires specification of number of qubits.")
+            raise ValueError("Symmetry-conserving Bravyi Kitaev requires specification of number of spin-orbitals.")
         if n_electrons is None:
             raise ValueError("Symmetry-conserving Bravyi Kitaev requires specification of number of electrons.")
 
@@ -127,7 +127,7 @@ def fermion_to_qubit_mapping(fermion_operator, mapping, n_spinorbitals=None, n_e
                                                            spin=spin)
     elif mapping.upper() == "JKMN":
         if n_spinorbitals is None:
-            raise ValueError("JKMN mapping requires specification of number of qubits")
+            raise ValueError("JKMN mapping requires specification of number of spin-orbitals.")
         qubit_operator = jkmn(fermion_operator, n_qubits=n_spinorbitals)
 
     converted_qubit_op = QubitOperator()


### PR DESCRIPTION
The main events:
- Restriction of the frozen orbitals (can't freeze orbitals with occupation == 1). There are inconsistencies with `pyscf` solvers when freezing half-filled MOs. At the moment, CASCI and MP2 do not work, CCSD does. Therefore, I think it is a good idea to raise an error until the issue https://github.com/pyscf/pyscf/issues/1331 is fixed/resolved.
- Changed qubits to spinorbitals in the fermion to qubit mapping function.
- Removed unused `frozen_orbitals` in `ADAPTSolver`.
- Fixed orbital selection in `FCISolver`.
- `VQESolver` raises an error when there is no var_params in the circuit.