### PR TITLE
Check for the number of target qubits

### DIFF
--- a/tangelo/linq/gate.py
+++ b/tangelo/linq/gate.py
@@ -99,7 +99,7 @@ class Gate(dict):
         else:
             n_targets = len(target)
         if len(target) != n_targets:
-            raise ValueError(f"Gate {g.name}: expected {n_targets} target qubits, but got {target}")
+            raise ValueError(f"Gate {name}: expected {n_targets} target qubits, but got {target}")
 
         self.__dict__ = {"name": name, "target": target, "control": control,
                          "parameter": parameter, "is_variational": is_variational}

--- a/tangelo/linq/gate.py
+++ b/tangelo/linq/gate.py
@@ -25,9 +25,9 @@ ONE_QUBIT_GATES = {"H", "X", "Y", "Z", "S", "T", "RX", "RY", "RZ", "PHASE"}
 TWO_QUBIT_GATES = {"CNOT", "CX", "CY", "CZ", "CRX", "CRY", "CRZ", "CPHASE", "XX", "SWAP"}
 THREE_QUBIT_GATES = {"CSWAP"}
 
-ONE_QUBIT_TARGET_GATES = {"H", "X", "Y", "Z", "S", "T", "RX", "RY", "RZ", "PHASE",
+ONE_TARGET_GATES = {"H", "X", "Y", "Z", "S", "T", "RX", "RY", "RZ", "PHASE",
                           "CNOT", "CX", "CY", "CZ", "CRX", "CRY", "CRZ", "CPHASE"}
-TWO_QUBIT_TARGET_GATES = {"XX", "SWAP", "CSWAP"}
+TWO_TARGET_GATES = {"XX", "SWAP", "CSWAP"}
 
 PARAMETERIZED_GATES = {"RX", "RY", "RZ", "PHASE", "CRX", "CRY", "CRZ", "CPHASE", "XX"}
 INVERTIBLE_GATES = {"H", "X", "Y", "Z", "S", "T", "RX", "RY", "RZ", "CH", "PHASE",
@@ -92,14 +92,14 @@ class Gate(dict):
         # Check for the number of qubits. If it is a custom gate (not defined in
         # the X_QUBIT_GATES sets), ignore the check. We also do not prevent
         # the creation of multi-controlled gates (begins with "C").
-        if name.upper() in ONE_QUBIT_TARGET_GATES:
-            n_qubits = 1
-        elif name.upper() in TWO_QUBIT_TARGET_GATES:
-            n_qubits = 2
+        if name.upper() in ONE_TARGET_GATES:
+            n_targets = 1
+        elif name.upper() in TWO_TARGET_GATES:
+            n_targets = 2
         else:
-            n_qubits = len(target)
-        if len(target) != n_qubits:
-            raise ValueError(f"There are too many target/control qubits for this gate.")
+            n_targets = len(target)
+        if len(target) != n_targets:
+            raise ValueError(f"Gate {g.name}: expected {n_targets} target qubits, but got {target}")
 
         self.__dict__ = {"name": name, "target": target, "control": control,
                          "parameter": parameter, "is_variational": is_variational}

--- a/tangelo/linq/gate.py
+++ b/tangelo/linq/gate.py
@@ -26,7 +26,7 @@ TWO_QUBIT_GATES = {"CNOT", "CX", "CY", "CZ", "CRX", "CRY", "CRZ", "CPHASE", "XX"
 THREE_QUBIT_GATES = {"CSWAP"}
 
 ONE_TARGET_GATES = {"H", "X", "Y", "Z", "S", "T", "RX", "RY", "RZ", "PHASE",
-                          "CNOT", "CX", "CY", "CZ", "CRX", "CRY", "CRZ", "CPHASE"}
+                    "CNOT", "CX", "CY", "CZ", "CRX", "CRY", "CRZ", "CPHASE"}
 TWO_TARGET_GATES = {"XX", "SWAP", "CSWAP"}
 
 PARAMETERIZED_GATES = {"RX", "RY", "RZ", "PHASE", "CRX", "CRY", "CRZ", "CPHASE", "XX"}

--- a/tangelo/linq/gate.py
+++ b/tangelo/linq/gate.py
@@ -24,6 +24,11 @@ from numpy import integer, ndarray, floating
 ONE_QUBIT_GATES = {"H", "X", "Y", "Z", "S", "T", "RX", "RY", "RZ", "PHASE"}
 TWO_QUBIT_GATES = {"CNOT", "CX", "CY", "CZ", "CRX", "CRY", "CRZ", "CPHASE", "XX", "SWAP"}
 THREE_QUBIT_GATES = {"CSWAP"}
+
+ONE_QUBIT_TARGET_GATES = {"H", "X", "Y", "Z", "S", "T", "RX", "RY", "RZ", "PHASE",
+                          "CNOT", "CX", "CY", "CZ", "CRX", "CRY", "CRZ", "CPHASE"}
+TWO_QUBIT_TARGET_GATES = {"XX", "SWAP", "CSWAP"}
+
 PARAMETERIZED_GATES = {"RX", "RY", "RZ", "PHASE", "CRX", "CRY", "CRZ", "CPHASE", "XX"}
 INVERTIBLE_GATES = {"H", "X", "Y", "Z", "S", "T", "RX", "RY", "RZ", "CH", "PHASE",
                     "CNOT", "CX", "CY", "CZ", "CRX", "CRY", "CRZ", "CPHASE", "XX", "SWAP"
@@ -83,6 +88,18 @@ class Gate(dict):
         all_involved_qubits = target if control is None else target + control
         if len(all_involved_qubits) != len(set(all_involved_qubits)):
             raise ValueError(f"There are duplicate qubits in the target/control qubits")
+
+        # Check for the number of qubits. If it is a custom gate (not defined in
+        # the X_QUBIT_GATES sets), ignore the check. We also do not prevent
+        # the creation of multi-controlled gates (begins with "C").
+        if name.upper() in ONE_QUBIT_TARGET_GATES:
+            n_qubits = 1
+        elif name.upper() in TWO_QUBIT_TARGET_GATES:
+            n_qubits = 2
+        else:
+            n_qubits = len(target)
+        if len(target) != n_qubits:
+            raise ValueError(f"There are too many target/control qubits for this gate.")
 
         self.__dict__ = {"name": name, "target": target, "control": control,
                          "parameter": parameter, "is_variational": is_variational}

--- a/tangelo/linq/tests/test_gates.py
+++ b/tangelo/linq/tests/test_gates.py
@@ -94,6 +94,15 @@ class TestGates(unittest.TestCase):
         self.assertTrue(g1 == g3)
         self.assertTrue(g2 == g3)
 
+    def test_too_many_qubits_on_gates(self):
+        """ Test the behavior when too many qubits are selected for a gate. """
+
+        # Trying to create a Hadamard gate acting on qubits 0 and 1.
+        self.assertRaises(ValueError, Gate, "H", target=[0, 1])
+
+        # Trying to create a XX gate acting on qubits 0, 1 and 2.
+        self.assertRaises(ValueError, Gate, "XX", target=[0, 1, 2])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tangelo/linq/tests/test_gates.py
+++ b/tangelo/linq/tests/test_gates.py
@@ -97,10 +97,10 @@ class TestGates(unittest.TestCase):
     def test_too_many_qubits_on_gates(self):
         """ Test the behavior when too many qubits are selected for a gate. """
 
-        # Trying to create a Hadamard gate acting on qubits 0 and 1.
+        # Try to create a Hadamard gate acting on qubits 0 and 1.
         self.assertRaises(ValueError, Gate, "H", target=[0, 1])
 
-        # Trying to create a XX gate acting on qubits 0, 1 and 2.
+        # Try to create a XX gate acting on qubits 0, 1 and 2.
         self.assertRaises(ValueError, Gate, "XX", target=[0, 1, 2])
 
 


### PR DESCRIPTION
Naive attempt at fixing https://github.com/goodchemistryco/Tangelo/issues/149. It checks the number of target qubits for some gates. It does not prevent multicontrolled-qubit gates nor custom gates.