### PR TITLE
Bug VQE.operator_expectation

### DIFF
--- a/tangelo/algorithms/variational/vqe_solver.py
+++ b/tangelo/algorithms/variational/vqe_solver.py
@@ -388,7 +388,7 @@ class VQESolver:
             raise TypeError("operator must be a of string, FermionOperator or QubitOperator type.")
 
         if isinstance(operator, (str, FermionOperator)):
-            if (n_active_electrons is None or n_active_sos is None or spin is None) and self.qubit_hamiltonian.mapping == "scbk":
+            if (n_active_electrons is None or n_active_sos is None or spin is None) and self.qubit_mapping == "scbk":
                 if self.molecule:
                     n_active_electrons = self.molecule.n_active_electrons
                     n_active_sos = self.molecule.n_active_sos
@@ -397,10 +397,10 @@ class VQESolver:
                     raise KeyError("Must supply n_active_electrons, n_active_sos, and spin with a FermionOperator and scbk mapping.")
 
             self.qubit_hamiltonian = fermion_to_qubit_mapping(fermion_operator=exp_op,
-                                                              mapping=self.qubit_hamiltonian.mapping,
+                                                              mapping=self.qubit_mapping,
                                                               n_spinorbitals=n_active_sos,
                                                               n_electrons=n_active_electrons,
-                                                              up_then_down=self.qubit_hamiltonian.up_then_down,
+                                                              up_then_down=self.up_then_down,
                                                               spin=spin)
 
         self.ansatz.update_var_params(var_params)


### PR DESCRIPTION
To fix another inconsistent behavior, we change the type of QubitHamiltonian to QubitOperator. This PR fixes an error that was raised because QubitOperator do not have mapping nor up_then_down as attributes.