### PR TITLE
Iterable circuit

### DIFF
--- a/tangelo/linq/circuit.py
+++ b/tangelo/linq/circuit.py
@@ -102,6 +102,10 @@ class Circuit:
         """
         return iter(self._gates)
 
+    def __next__(self):
+        """Define the next function when calling next(Circuit). """
+        return next(self._gates)
+
     @property
     def size(self):
         """The size is the number of gates in the circuit. It is different from

--- a/tangelo/linq/circuit.py
+++ b/tangelo/linq/circuit.py
@@ -96,6 +96,12 @@ class Circuit:
         """
         return not (self == other)
 
+    def __iter__(self):
+        """Define the iterator. This is useful when iterating through all the
+        gates in a Circuit.
+        """
+        return iter(self._gates)
+
     @property
     def size(self):
         """The size is the number of gates in the circuit. It is different from

--- a/tangelo/linq/tests/test_circuits.py
+++ b/tangelo/linq/tests/test_circuits.py
@@ -284,6 +284,13 @@ class TestCircuits(unittest.TestCase):
 
         self.assertEqual(test_circuit.width, 1)
 
+    def test_iterate(self):
+        """ Test if the iteration returns the expected list of gates. """
+
+        self.assertEqual([g for g in circuit2], circuit2._gates)
+        self.assertEqual([g for g in circuit3], circuit3._gates)
+        self.assertEqual([g for g in circuit4], circuit4._gates)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Allow users to traverse a circuit object, in order to iterate over gates.

```python
# Create circuit with a dummy list of gates
gates = ['H', 'X', 'CNOT', 'RZ']
c = Circuit(gates)

# Now, traversing the circuit is equivalent to iterating over gates
for g in c:
    print(g)
```