### PR TITLE
translate qiskit.QuantumCircuit to Circuit 

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Install backends except qsharp/qdk
       run: |
-        pip install qiskit==0.33.1 # Due to strange behaviour of noise model
+        pip install qiskit
         pip install qulacs
         pip install amazon-braket-sdk
         pip install cirq

--- a/tangelo/linq/gate.py
+++ b/tangelo/linq/gate.py
@@ -125,7 +125,10 @@ class Gate(dict):
 
         ds, do = self.__dict__, other.__dict__
 
-        if any(ds[k] != do[k] for k in ds if k != "parameter"):
+        # Check CNOT CX Separately
+        ignore_list = ["name", "parameter"] if ds["name"] in ["CNOT", "CX"] and do["name"] in ["CNOT", "CX"] else ["parameter"]
+
+        if any(ds[k] != do[k] for k in ds if k not in ignore_list):
             return False
 
         parameter = round(ds["parameter"] % (2 * pi), 7) if isinstance(ds["parameter"], (float, int)) else ds["parameter"]

--- a/tangelo/linq/gate.py
+++ b/tangelo/linq/gate.py
@@ -125,7 +125,8 @@ class Gate(dict):
 
         ds, do = self.__dict__, other.__dict__
 
-        # Check CNOT CX Separately
+        # CNOT and CX gates are equivalent. If both gates are either CNOT or CX, the names are equivalent and can
+        # be ignored for equivalence checks later.
         ignore_list = ["name", "parameter"] if ds["name"] in ["CNOT", "CX"] and do["name"] in ["CNOT", "CX"] else ["parameter"]
 
         if any(ds[k] != do[k] for k in ds if k not in ignore_list):

--- a/tangelo/linq/tests/test_translator.py
+++ b/tangelo/linq/tests/test_translator.py
@@ -20,6 +20,7 @@
 import unittest
 import os
 import numpy as np
+import time
 
 from tangelo.linq import Gate, Circuit
 from tangelo.linq.gate import PARAMETERIZED_GATES
@@ -165,9 +166,19 @@ class TestTranslation(unittest.TestCase):
         # Generate the qiskit circuit by translating from the abstract one and print it
         translated_circuit = translator.translate_qiskit(big_circuit)
 
-        # Test inverse translation function
-        big_circuit_translated_back = translator.translate_qiskit(translated_circuit)
-        self.assertEqual(big_circuit_translated_back, big_circuit)
+        # Big translate/translate back test (32000 gates)
+        very_big_circuit = big_circuit*10**3
+        tstart1 = time.time()
+        qc_very_big_circuit = translator.translate_c_to_qiskit(very_big_circuit)
+        tstop1 = time.time()
+        print(f"Circuit -> QuantumCircuit took {tstop1-tstart1:.2f} s")
+
+        tstart2 = time.time()
+        c_very_big_circuit = translator.translate_c_from_qiskit(qc_very_big_circuit)
+        tstop2 = time.time()
+        print(f"QuantumCircuit -> Circuit took {tstop2-tstart2:.2f} s")
+
+        self.assertEqual(c_very_big_circuit, very_big_circuit)
 
         # Simulate both circuits, assert state vectors are equal
         qiskit_simulator = AerSimulator(method='statevector')

--- a/tangelo/linq/tests/test_translator.py
+++ b/tangelo/linq/tests/test_translator.py
@@ -181,7 +181,7 @@ class TestTranslation(unittest.TestCase):
         self.assertEqual(c_very_big_circuit, very_big_circuit)
 
         # Simulate both circuits, assert state vectors are equal
-        qiskit_simulator = AerSimulator(method='statevector')
+        qiskit_simulator = AerSimulator(method="statevector")
         translated_circuit = qiskit.transpile(translated_circuit, qiskit_simulator)
         translated_circuit.save_statevector()
         sim_results = qiskit_simulator.run(translated_circuit).result()

--- a/tangelo/linq/tests/test_translator.py
+++ b/tangelo/linq/tests/test_translator.py
@@ -130,6 +130,7 @@ class TestTranslation(unittest.TestCase):
         """
 
         import qiskit
+        from qiskit.providers.aer import AerSimulator
 
         # Generate the qiskit circuit by translating from the abstract one and print it
         translated_circuit = translator.translate_qiskit(abs_circ)
@@ -144,7 +145,7 @@ class TestTranslation(unittest.TestCase):
         circ.rx(2., 1)
 
         # Simulate both circuits, assert state vectors are equal
-        qiskit_simulator = qiskit.Aer.get_backend("aer_simulator", method='statevector')
+        qiskit_simulator = AerSimulator(method="statevector")
         translated_circuit = qiskit.transpile(translated_circuit, qiskit_simulator)
         circ = qiskit.transpile(circ, qiskit_simulator)
         translated_circuit.save_statevector()
@@ -163,8 +164,13 @@ class TestTranslation(unittest.TestCase):
 
         # Generate the qiskit circuit by translating from the abstract one and print it
         translated_circuit = translator.translate_qiskit(big_circuit)
+
+        # Test inverse translation function
+        big_circuit_translated_back = translator.translate_qiskit(translated_circuit)
+        self.assertEqual(big_circuit_translated_back, big_circuit)
+
         # Simulate both circuits, assert state vectors are equal
-        qiskit_simulator = qiskit.Aer.get_backend("aer_simulator", method='statevector')
+        qiskit_simulator = AerSimulator(method='statevector')
         translated_circuit = qiskit.transpile(translated_circuit, qiskit_simulator)
         translated_circuit.save_statevector()
         sim_results = qiskit_simulator.run(translated_circuit).result()

--- a/tangelo/linq/translator/__init__.py
+++ b/tangelo/linq/translator/__init__.py
@@ -15,7 +15,7 @@
 from tangelo.helpers.utils import installed_backends
 
 from .translate_braket import translate_braket, get_braket_gates
-from .translate_qiskit import translate_qiskit, get_qiskit_gates
+from .translate_qiskit import translate_qiskit, get_qiskit_gates, translate_c_from_qiskit, translate_c_to_qiskit
 from .translate_qulacs import translate_qulacs, get_qulacs_gates
 from .translate_cirq import translate_cirq, get_cirq_gates
 from .translate_json_ionq import translate_json_ionq, get_ionq_gates

--- a/tangelo/linq/translator/translate_qiskit.py
+++ b/tangelo/linq/translator/translate_qiskit.py
@@ -24,6 +24,7 @@ necessary to account for:
 The module also enables bidirectional conversion between qiskit and Tangelo
 qubit operators (linear combination of Pauli operators)
 """
+from tangelo.linq import Circuit, Gate
 
 from tangelo.toolboxes.operators import QubitOperator
 from tangelo.linq.helpers import pauli_of_to_string, pauli_string_to_of
@@ -65,44 +66,73 @@ def get_qiskit_gates():
 
 
 def translate_qiskit(source_circuit):
-    """Take in an abstract circuit, return an equivalent qiskit QuantumCircuit
-    instance
+    """Take in a Circuit, return an equivalent qiskit.QuantumCircuit OR take in a qiskit.QuantumCircuit return an equivalent Circuit
 
     Args:
-        source_circuit: quantum circuit in the abstract format.
+        source_circuit (Circuit or qiskit.QuantumCircuit): quantum circuit in the abstract format.
 
     Returns:
-        qiskit.QuantumCircuit: the corresponding qiskit quantum circuit.
+        qiskit.QuantumCircuit or Circuit: the corresponding quantum circuit.
     """
 
     import qiskit
 
     GATE_QISKIT = get_qiskit_gates()
-    target_circuit = qiskit.QuantumCircuit(source_circuit.width, source_circuit.width)
 
-    # Maps the gate information properly. Different for each backend (order, values)
-    for gate in source_circuit._gates:
-        if gate.control is not None:
-            if len(gate.control) > 1:
-                raise ValueError('Multi-controlled gates not supported with qiskit. Gate {gate.name} with controls {gate.control} is not allowed')
-        if gate.name in {"H", "X", "Y", "Z", "S", "T"}:
-            (GATE_QISKIT[gate.name])(target_circuit, gate.target[0])
-        elif gate.name in {"RX", "RY", "RZ", "PHASE"}:
-            (GATE_QISKIT[gate.name])(target_circuit, gate.parameter, gate.target[0])
-        elif gate.name in {"CRX", "CRY", "CRZ", "CPHASE"}:
-            (GATE_QISKIT[gate.name])(target_circuit, gate.parameter, gate.control[0], gate.target[0])
-        elif gate.name in {"CNOT", "CH", "CX", "CY", "CZ"}:
-            (GATE_QISKIT[gate.name])(target_circuit, gate.control[0], gate.target[0])
-        elif gate.name in {"SWAP"}:
-            (GATE_QISKIT[gate.name])(target_circuit, gate.target[0], gate.target[1])
-        elif gate.name in {"CSWAP"}:
-            (GATE_QISKIT[gate.name])(target_circuit, gate.control[0], gate.target[0], gate.target[1])
-        elif gate.name in {"XX"}:
-            (GATE_QISKIT[gate.name])(target_circuit, gate.parameter, gate.target[0], gate.target[1])
-        elif gate.name in {"MEASURE"}:
-            (GATE_QISKIT[gate.name])(target_circuit, gate.target[0], gate.target[0])
-        else:
-            raise ValueError(f"Gate '{gate.name}' not supported on backend qiskit")
+    if isinstance(source_circuit, Circuit):
+        target_circuit = qiskit.QuantumCircuit(source_circuit.width, source_circuit.width)
+
+        # Maps the gate information properly. Different for each backend (order, values)
+        for gate in source_circuit._gates:
+            if gate.control is not None:
+                if len(gate.control) > 1:
+                    raise ValueError('Multi-controlled gates not supported with qiskit. Gate {gate.name} with controls {gate.control} is not allowed')
+            if gate.name in {"H", "Y", "X", "Z", "S", "T"}:
+                (GATE_QISKIT[gate.name])(target_circuit, gate.target[0])
+            elif gate.name in {"RX", "RY", "RZ", "PHASE"}:
+                (GATE_QISKIT[gate.name])(target_circuit, gate.parameter, gate.target[0])
+            elif gate.name in {"CRX", "CRY", "CRZ", "CPHASE"}:
+                (GATE_QISKIT[gate.name])(target_circuit, gate.parameter, gate.control[0], gate.target[0])
+            elif gate.name in {"CNOT", "CH", "CX", "CY", "CZ"}:
+                (GATE_QISKIT[gate.name])(target_circuit, gate.control[0], gate.target[0])
+            elif gate.name in {"SWAP"}:
+                (GATE_QISKIT[gate.name])(target_circuit, gate.target[0], gate.target[1])
+            elif gate.name in {"CSWAP"}:
+                (GATE_QISKIT[gate.name])(target_circuit, gate.control[0], gate.target[0], gate.target[1])
+            elif gate.name in {"XX"}:
+                (GATE_QISKIT[gate.name])(target_circuit, gate.parameter, gate.target[0], gate.target[1])
+            elif gate.name in {"MEASURE"}:
+                (GATE_QISKIT[gate.name])(target_circuit, gate.target[0], gate.target[0])
+            else:
+                raise ValueError(f"Gate '{gate.name}' not supported on backend qiskit")
+    elif isinstance(source_circuit, qiskit.QuantumCircuit):
+        qi = source_circuit._qubit_indices
+        inv_GATE_QISKIT = {v.__name__: k for k, v in GATE_QISKIT.items()}
+
+        gates = []
+        for gate in source_circuit:
+            name = inv_GATE_QISKIT[gate.operation.name]
+            if name in {"H", "X", "Y", "Z", "S", "T"}:
+                gates += [Gate(name, qi[gate.qubits[0]].index)]
+            elif name in {"RX", "RY", "RZ", "PHASE"}:
+                gates += [Gate(name, qi[gate.qubits[0]].index, parameter=gate.operation.params[0])]
+            elif name in {"CRX", "CRY", "CRZ", "CPHASE"}:
+                gates += [Gate(name, qi[gate.qubits[1]].index, control=qi[gate.qubits[0]].index, parameter=gate.operation.params[0])]
+            elif name in {"CNOT", "CH", "CX", "CY", "CZ"}:
+                gates += [Gate(name, qi[gate.qubits[1]].index, control=qi[gate.qubits[0]].index)]
+            elif name in {"SWAP"}:
+                gates += [Gate(name, [qi[gate.qubits[0]].index, qi[gate.qubits[1]].index])]
+            elif name in {"CSWAP"}:
+                gates += [Gate(name, [qi[gate.qubits[1]].index, qi[gate.qubits[2]].index], control=qi[gate.qubits[0]].index)]
+            elif name in {"XX"}:
+                gates += [Gate(name, [qi[gate.qubits[0]].index, qi[gate.qubits[1]].index], parameter=gate.operation.params[0])]
+            elif name in {"MEASURE"}:
+                gates += [Gate(name, qi[gate.qubits[0]].index)]
+            else:
+                raise ValueError(f"Gate '{gate.name}' not supported on backend qiskit")
+        target_circuit = Circuit(gates)
+    else:
+        raise TypeError(f"Only types of {Circuit} and {qiskit.QuantumCircuit} can be translated in translate_qiskit")
     return target_circuit
 
 

--- a/tangelo/linq/translator/translate_qiskit.py
+++ b/tangelo/linq/translator/translate_qiskit.py
@@ -30,7 +30,7 @@ from tangelo.linq.helpers import pauli_of_to_string, pauli_string_to_of
 
 
 def get_qiskit_gates():
-    """Map gate name of the abstract format to the equivalent add_gate method of
+    """Map gate name of the Tangelo format to the equivalent add_gate method of
     Qiskit's QuantumCircuit class API and supported gates:
     https://qiskit.org/documentation/stubs/qiskit.circuit.QuantumCircuit.html
     """
@@ -68,10 +68,10 @@ def translate_qiskit(source_circuit):
     """Take in a Circuit, return an equivalent qiskit.QuantumCircuit
 
     Args:
-        source_circuit (Circuit): quantum circuit in the abstract format.
+        source_circuit (Circuit): quantum circuit in the Tangelo format.
 
     Returns:
-        qiskit.QuantumCircuit: the corresponding quantum circuit.
+        qiskit.QuantumCircuit: the corresponding quantum circuit in Qiskit format.
     """
 
     return translate_c_to_qiskit(source_circuit)
@@ -81,7 +81,7 @@ def translate_c_to_qiskit(source_circuit: Circuit):
     """Take in a Circuit, return an equivalent qiskit.QuantumCircuit
 
     Args:
-        source_circuit (Circuit): quantum circuit in the abstract format.
+        source_circuit (Circuit): quantum circuit in the Tangelo format.
 
     Returns:
         qiskit.QuantumCircuit: the corresponding qiskit.QuantumCircuit
@@ -120,13 +120,13 @@ def translate_c_to_qiskit(source_circuit: Circuit):
 
 
 def translate_c_from_qiskit(source_circuit) -> Circuit:
-    """Take in a qiskit.QuantumCircuit, return an equivalent Circuit
+    """Take in a qiskit.QuantumCircuit, return an equivalent Tangelo Circuit
 
     Args:
-        source_circuit (qiskit.QuantumCircuit): quantum circuit in the abstract qiskit.QuantumCircuit format.
+        source_circuit (qiskit.QuantumCircuit): quantum circuit in the qiskit.QuantumCircuit format.
 
     Returns:
-        Circuit: the corresponding quantum Circuit.
+        Circuit: the corresponding quantum Circuit in Tangelo format.
     """
     import qiskit
 
@@ -154,7 +154,7 @@ def translate_c_from_qiskit(source_circuit) -> Circuit:
         elif name in {"MEASURE"}:
             gates += [Gate(name, qi[gate.qubits[0]].index)]
         else:
-            raise ValueError(f"Gate '{gate.name}' not supported on backend qiskit")
+            raise ValueError(f"Gate '{gate.name}' not supported in Tangelo")
     target_circuit = Circuit(gates)
 
     return target_circuit


### PR DESCRIPTION
Change `translate_qiskit` such that a qiskit.QuantumCircuit with supported gates can be translated to Circuit format.