### PR TITLE
Remove the n_min_orbitals attribute

### DIFF
--- a/tangelo/toolboxes/molecular_computation/molecule.py
+++ b/tangelo/toolboxes/molecular_computation/molecule.py
@@ -91,13 +91,11 @@ class Molecule:
     # Defined in __post_init__.
     n_atoms: int = field(init=False)
     n_electrons: int = field(init=False)
-    n_min_orbitals: int = field(init=False)
 
     def __post_init__(self):
         mol = self.to_pyscf()
         self.n_atoms = mol.natm
         self.n_electrons = mol.nelectron
-        self.n_min_orbitals = mol.nao_nr()
 
     @property
     def elements(self):


### PR DESCRIPTION
This attributes was meant to store the number of orbitals when using a minimal basis set. Changing the default basis cause this attribute to output wrong values, thus causing inconsistencies. This attribute is not used in our code base.