### PR TITLE
Change JKMN Majorana definition so mapped Hamiltonian is real

### DIFF
--- a/tangelo/toolboxes/qubit_mappings/jkmn.py
+++ b/tangelo/toolboxes/qubit_mappings/jkmn.py
@@ -136,8 +136,8 @@ def _jkmn_dict(n_qubits):
                 stjkmn_map[2*tup[0]] = tjkmn_map[2*i]
                 stjkmn_map[2*tup[0]+1] = tjkmn_map[2*i+1]
             elif tup[1] == 'Y' and (tup[0], 'X') in q2:
-                stjkmn_map[2*tup[0]+1] = tjkmn_map[2*i]
-                stjkmn_map[2*tup[0]] = tjkmn_map[2*i+1]
+                stjkmn_map[2*tup[0]] = -tjkmn_map[2*i]
+                stjkmn_map[2*tup[0]+1] = tjkmn_map[2*i+1]
 
     return stjkmn_map
 

--- a/tangelo/toolboxes/qubit_mappings/tests/test_mapping_transform.py
+++ b/tangelo/toolboxes/qubit_mappings/tests/test_mapping_transform.py
@@ -75,10 +75,10 @@ class MappingTest(unittest.TestCase):
         jkmn_operator += QubitOperator(((0, "X"), (2, "Z"), (3, "Y")), 0.125j)
         jkmn_operator += QubitOperator(((0, "Y"), (1, "Z"), (3, "X")), -0.125j)
         jkmn_operator += QubitOperator(((0, "Y"), (1, "Z"), (3, "Y")), 0.125)
-        jkmn_operator += QubitOperator(((0, "Z"), (1, "X"), (2, "X")), 0.25j)
-        jkmn_operator += QubitOperator(((0, "Z"), (1, "X"), (2, "Y")), 0.25)
-        jkmn_operator += QubitOperator(((0, "Z"), (1, "Y"), (2, "X")), -0.25)
-        jkmn_operator += QubitOperator(((0, "Z"), (1, "Y"), (2, "Y")), 0.25j)
+        jkmn_operator += QubitOperator(((0, "Z"), (1, "X"), (2, "X")), 0.25)
+        jkmn_operator += QubitOperator(((0, "Z"), (1, "X"), (2, "Y")), -0.25j)
+        jkmn_operator += QubitOperator(((0, "Z"), (1, "Y"), (2, "X")), 0.25j)
+        jkmn_operator += QubitOperator(((0, "Z"), (1, "Y"), (2, "Y")), 0.25)
 
         fermion = FermionOperator(((1, 0), (2, 1)), 1.0) + FermionOperator(((0, 1), (3, 0)), 0.5)
 


### PR DESCRIPTION
The previous implementation resulted in a Qubit Hamiltonian that had real and imaginary parts. This change ensures that a real FermionOperator will be mapped to a real QubitOperator. (i.e. even number of Y elements with real coefficient or odd number of Y elements terms with imaginary coefficient)