### PR TITLE
Relaxing iqcc_ilc_h4_cation test

### DIFF
--- a/tangelo/algorithms/variational/tests/test_iqcc_ilc_solver.py
+++ b/tangelo/algorithms/variational/tests/test_iqcc_ilc_solver.py
@@ -84,7 +84,7 @@ class iQCC_ILC_solver_test(unittest.TestCase):
         iqcc_ilc_solver.build()
         iqcc_ilc_energy = iqcc_ilc_solver.simulate()
 
-        self.assertAlmostEqual(iqcc_ilc_energy, -1.638197, places=4)
+        self.assertAlmostEqual(iqcc_ilc_energy, -1.638, places=2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I noticed there are 2 possible solutions (-1.638999 and -1.638197) with the iqcc_ilc_h4_cation test. This is maybe an underlying consequence of the iQCC-ILC algorithm. 