### PR TITLE
add __repr__ method to Gate

### DIFF
--- a/tangelo/linq/gate.py
+++ b/tangelo/linq/gate.py
@@ -120,6 +120,22 @@ class Gate(dict):
 
         return mystr
 
+    def __repr__(self):
+        """Represent gate such that eval(self.__repr__) returns a proper instance of Gate."""
+
+        mystr = f"Gate(name='{self.name}'"
+        for attr in ["target", "control"]:
+            if self.__getattribute__(attr) or isinstance(self.__getattribute__(attr), int):
+                mystr += f", {attr}={self.__getattribute__(attr)}"
+        if self.__getattribute__("parameter") != "":
+            parameter = self.__getattribute__('parameter')
+            mystr += f", parameter='{parameter}'" if isinstance(parameter, str) else f", parameter={parameter}"
+        if self.is_variational:
+            mystr += ", is_variational=True"
+        mystr += ")"
+
+        return mystr
+
     def __eq__(self, other):
         """Define equality (==) operator on gates"""
 

--- a/tangelo/linq/tests/test_gates.py
+++ b/tangelo/linq/tests/test_gates.py
@@ -43,6 +43,24 @@ class TestGates(unittest.TestCase):
         for gate in [H_gate, CNOT_gate, RX_gate, RZ_gate, CCCX_gate]:
             print(gate)
 
+    def test_repr(self):
+        """ Test that some basic gates can be invoked with a few different parameters, and that this information
+        is printed as expected by the built-in __repr__ method end eval(gate.__repr__()) returns the same gate."""
+
+        # Create a Hadamard gate acting on qubit 2
+        H_gate = Gate("H", 2)
+        # Create a CNOT gate with control qubit 0 and target qubit 1
+        CNOT_gate = Gate("CNOT", 1, 0)
+        # Create a parameterized rotation on qubit 1 with angle 2 radians
+        RX_gate = Gate("RX", 1, parameter=2.)
+        # Create a parameterized rotation on qubit 1 , with an undefined angle, that will be variational
+        RZ_gate = Gate("RZ", 1, parameter="an expression", is_variational=True)
+        # Create a multi-controlled X gate with a numpy array
+        CCCX_gate = Gate("CX", 0, control=np.array([1, 2, 4], dtype=np.int32))
+
+        for gate in [H_gate, CNOT_gate, RX_gate, RZ_gate, CCCX_gate]:
+            self.assertEqual(eval(gate.__repr__()), gate)
+
     def test_some_gates_inverse(self):
         """ Test that some basic gates can be inverted with a few different parameters, and fails when non-invertible
         parameters are passed"""


### PR DESCRIPTION
Some of our functions return a list of gates such as measurement_basis_gates. Without a repr method printing this return results in the output
```
>>> from tangelo.linq import Gate
>>> from tangelo.linq.helpers.circuits import measurement_basis_gates
>>> m = measurement_basis_gates(((0, "Y"), (1, "X")))
>>> print(m)
[{}, {}]
>>> m
[{}, {}]
```
With repr, the following output occurs.
```
>>> from tangelo.linq.helpers.circuits import measurement_basis_gates
>>> m = measurement_basis_gates(((0, "Y"), (1, "X")))
>>> print(m)
[Gate(name='RX', target=[0], parameter=1.5707963267948966), Gate(name='RY', target=[1], parameter=-1.5707963267948966)]
>>> m
[Gate(name='RX', target=[0], parameter=1.5707963267948966), Gate(name='RY', target=[1], parameter=-1.5707963267948966)]
```
Also `eval(gate.__repr__()) == gate`.