### PR TITLE
trotter order and  active electrons for QCC/iQCC

### DIFF
--- a/tangelo/algorithms/variational/tests/test_iqcc_solver.py
+++ b/tangelo/algorithms/variational/tests/test_iqcc_solver.py
@@ -70,9 +70,9 @@ class iQCC_solver_test(unittest.TestCase):
         self.assertAlmostEqual(iqcc_energy, -1.96259, places=4)
 
     def test_iqcc_h4_cation(self):
-        """Test the energy after 3 iterations for H4+"""
+        """Test the energy after 3 iterations for H4+ with generators limited to 8"""
 
-        ansatz_options = {"max_qcc_gens": None}
+        ansatz_options = {"max_qcc_gens": 8}
 
         iqcc_options = {"molecule": mol_H4_cation_sto3g,
                         "qubit_mapping": "scbk",

--- a/tangelo/algorithms/variational/vqe_solver.py
+++ b/tangelo/algorithms/variational/vqe_solver.py
@@ -192,6 +192,8 @@ class VQESolver:
                                                      up_then_down=self.up_then_down,
                                                      spin=self.molecule.spin)
                 self.qubit_hamiltonian += pen_qubit
+                if self.ansatz == BuiltInAnsatze.QCC:
+                    self.ansatz_options["qubit_ham"] = self.qubit_hamiltonian.to_qubitoperator()
 
             # Verification of system compatibility with UCC1 or UCC3 circuits.
             if self.ansatz in [BuiltInAnsatze.UCC1, BuiltInAnsatze.UCC3]:

--- a/tangelo/toolboxes/ansatz_generator/qcc.py
+++ b/tangelo/toolboxes/ansatz_generator/qcc.py
@@ -92,7 +92,7 @@ class QCC(Ansatz):
         self.molecule = molecule
         if isinstance(self.molecule, SecondQuantizedMolecule):
             self.n_spinorbitals = self.molecule.n_active_sos
-            self.n_electrons = self.molecule.n_electrons
+            self.n_electrons = self.molecule.n_active_electrons
             self.spin = self.molecule.spin
         elif isinstance(self.molecule, dict):
             self.n_spinorbitals = self.molecule["n_spinorbitals"]


### PR DESCRIPTION
Various bug fixes for iQCC.

- Trotter ordering not captured properly
- Used n_electrons instead of n_active_electrons.