### PR TITLE
Add multi-control support for trotterization

### DIFF
--- a/tangelo/toolboxes/ansatz_generator/ansatz_utils.py
+++ b/tangelo/toolboxes/ansatz_generator/ansatz_utils.py
@@ -136,7 +136,11 @@ def get_exponentiated_qubit_operator_circuit(qubit_op, time=1., variational=Fals
             if control is None:
                 phase *= np.exp(-1j * np.real(coef))
             else:
-                exp_pauli_word_gates += [Gate("PHASE", target=control, parameter=-np.real(coef))]
+                if isinstance(control, int) or len(control) == 1:
+                    exp_pauli_word_gates += [Gate("PHASE", target=control, parameter=-np.real(coef))]
+                else:
+                    exp_pauli_word_gates += [Gate("CPHASE", target=0, control=control, parameter=-2*np.real(coef))]
+                    exp_pauli_word_gates += [Gate("CRZ", target=0, control=control, parameter=2*np.real(coef))]
 
     return_value = (Circuit(exp_pauli_word_gates), phase) if return_phase else Circuit(exp_pauli_word_gates)
     return return_value

--- a/tangelo/toolboxes/ansatz_generator/ansatz_utils.py
+++ b/tangelo/toolboxes/ansatz_generator/ansatz_utils.py
@@ -70,7 +70,7 @@ def exp_pauliword_to_gates(pauli_word, coef, variational=True, control=None):
     if control is None:
         gates += [Gate("RZ", target=indices[-1], parameter=angle, is_variational=variational)]
     else:
-        gates += [Gate("CRZ", target=indices[-1], control=control, parameter=angle)]
+        gates += [Gate("CRZ", target=indices[-1], control=control, parameter=angle, is_variational=variational)]
 
     gates += cnot_ladder_gates[::-1]
 
@@ -137,10 +137,10 @@ def get_exponentiated_qubit_operator_circuit(qubit_op, time=1., variational=Fals
                 phase *= np.exp(-1j * np.real(coef))
             else:
                 if isinstance(control, int) or len(control) == 1:
-                    exp_pauli_word_gates += [Gate("PHASE", target=control, parameter=-np.real(coef))]
+                    exp_pauli_word_gates += [Gate("PHASE", target=control, parameter=-np.real(coef), is_variational=variational)]
                 else:
-                    exp_pauli_word_gates += [Gate("CPHASE", target=0, control=control, parameter=-2*np.real(coef))]
-                    exp_pauli_word_gates += [Gate("CRZ", target=0, control=control, parameter=2*np.real(coef))]
+                    exp_pauli_word_gates += [Gate("CPHASE", target=0, control=control, parameter=-2*np.real(coef), is_variational=variational)]
+                    exp_pauli_word_gates += [Gate("CRZ", target=0, control=control, parameter=2*np.real(coef), is_variational=variational)]
 
     return_value = (Circuit(exp_pauli_word_gates), phase) if return_phase else Circuit(exp_pauli_word_gates)
     return return_value


### PR DESCRIPTION
The current implementation makes a simplification for when an identity qubit operator is trotterized that is not applicable for multiple controls. This is fixed. 