### PR TITLE
allow single flip index dis for qcc

### DIFF
--- a/tangelo/algorithms/variational/tests/test_iqcc_ilc_solver.py
+++ b/tangelo/algorithms/variational/tests/test_iqcc_ilc_solver.py
@@ -62,7 +62,7 @@ class iQCC_ILC_solver_test(unittest.TestCase):
         iqcc_ilc_solver.build()
         iqcc_ilc_energy = iqcc_ilc_solver.simulate()
 
-        self.assertAlmostEqual(iqcc_ilc_energy, -1.976817, places=4)
+        self.assertAlmostEqual(iqcc_ilc_energy, -1.9786, places=3)
 
     def test_iqcc_ilc_h4_cation(self):
         """Test the energy after 2 iterations for H4+ using the maximum

--- a/tangelo/algorithms/variational/tests/test_iqcc_solver.py
+++ b/tangelo/algorithms/variational/tests/test_iqcc_solver.py
@@ -85,7 +85,7 @@ class iQCC_solver_test(unittest.TestCase):
         iqcc.build()
         iqcc_energy = iqcc.simulate()
 
-        self.assertAlmostEqual(iqcc_energy, -1.638524, places=4)
+        self.assertAlmostEqual(iqcc_energy, -1.639, places=3)
 
     def test_iqcc_h4_double_cation(self):
         """Test the energy after 1 iteration for H4+2"""

--- a/tangelo/toolboxes/ansatz_generator/_qubit_cc.py
+++ b/tangelo/toolboxes/ansatz_generator/_qubit_cc.py
@@ -130,8 +130,8 @@ def get_idxs_deriv(qham_term, *qham_qmf_data):
             gen = (idx, "Y") if idxs == "" else (idx, "X")
             idxs = idxs + f" {idx}" if idxs != "" else f"{idx}"
             gen_tup += (gen, )
-    # Generators must have at least two flip indices
-    if len(gen_tup) > 1:
+    # Generators must have at least one flip index
+    if len(gen_tup) > 0:
         qham_gen_comm = QubitOperator(qham_term, -1j * coef)
         qham_gen_comm *= QubitOperator(gen_tup, 1.)
         deriv = get_op_expval(qham_gen_comm, pure_params).real
@@ -152,7 +152,7 @@ def get_gens_from_idxs(group_idxs):
     """
 
     dis_group_gens = []
-    for n_y in range(1, len(group_idxs), 2):
+    for n_y in range(1, len(group_idxs)+1, 2):
         # Create combinations of odd numbers of flip indices for the Pauli Y operators
         for xy_idx in combinations(group_idxs, n_y):
             # If a flip index idx matches xy_idx, add a Y operator


### PR DESCRIPTION
JKMN mapping requires single flip index generators to converge using QCC. This PR allows a single flip index DIS group where the smallest size before was 2.