### PR TITLE
DMET bug with QCC

### DIFF
--- a/tangelo/problem_decomposition/dmet/dmet_problem_decomposition.py
+++ b/tangelo/problem_decomposition/dmet/dmet_problem_decomposition.py
@@ -176,6 +176,9 @@ class DMETProblemDecomposition(ProblemDecomposition):
         self.orb_list2 = None
         self.onerdm_low = None
 
+        # If save_results in _oneshot_loop is True, the dict is populated.
+        self.solver_fragment_dict = dict()
+
     @property
     def quantum_fragments_data(self):
         """This aims to return a dictionary with all necessary components to

--- a/tangelo/problem_decomposition/dmet/fragment.py
+++ b/tangelo/problem_decomposition/dmet/fragment.py
@@ -20,6 +20,7 @@ import numpy as np
 import pyscf
 from pyscf import ao2mo
 
+from tangelo import SecondQuantizedMolecule
 from tangelo.toolboxes.operators import FermionOperator
 from tangelo.toolboxes.qubit_mappings.mapping_transform import get_fermion_operator
 
@@ -62,6 +63,11 @@ class SecondQuantizedDMETFragment:
 
         self.fermionic_hamiltonian = self._get_fermionic_hamiltonian()
         self.frozen_mos = None
+
+    @property
+    def __class__(self):
+        # Tricking isinstance fucntion.
+        return SecondQuantizedMolecule
 
     def _get_fermionic_hamiltonian(self):
         """This method returns the fermionic hamiltonian. It written to take

--- a/tangelo/problem_decomposition/dmet/fragment.py
+++ b/tangelo/problem_decomposition/dmet/fragment.py
@@ -20,7 +20,6 @@ import numpy as np
 import pyscf
 from pyscf import ao2mo
 
-from tangelo import SecondQuantizedMolecule
 from tangelo.toolboxes.operators import FermionOperator
 from tangelo.toolboxes.qubit_mappings.mapping_transform import get_fermion_operator
 

--- a/tangelo/problem_decomposition/dmet/fragment.py
+++ b/tangelo/problem_decomposition/dmet/fragment.py
@@ -66,7 +66,7 @@ class SecondQuantizedDMETFragment:
 
     @property
     def __class__(self):
-        # Tricking isinstance fucntion.
+        # Tricking isinstance function.
         return SecondQuantizedMolecule
 
     def _get_fermionic_hamiltonian(self):

--- a/tangelo/problem_decomposition/dmet/fragment.py
+++ b/tangelo/problem_decomposition/dmet/fragment.py
@@ -64,11 +64,6 @@ class SecondQuantizedDMETFragment:
         self.fermionic_hamiltonian = self._get_fermionic_hamiltonian()
         self.frozen_mos = None
 
-    @property
-    def __class__(self):
-        # Tricking isinstance function.
-        return SecondQuantizedMolecule
-
     def _get_fermionic_hamiltonian(self):
         """This method returns the fermionic hamiltonian. It written to take
         into account calls for this function is without argument, and attributes

--- a/tangelo/toolboxes/ansatz_generator/qcc.py
+++ b/tangelo/toolboxes/ansatz_generator/qcc.py
@@ -40,8 +40,6 @@ import numpy as np
 from tangelo.toolboxes.qubit_mappings.mapping_transform import get_qubit_number,\
                                                                fermion_to_qubit_mapping
 from tangelo.linq import Circuit
-from tangelo import SecondQuantizedMolecule
-from tangelo.problem_decomposition.dmet.fragment import SecondQuantizedDMETFragment
 from tangelo.toolboxes.ansatz_generator.ansatz import Ansatz
 from tangelo.toolboxes.ansatz_generator.ansatz_utils import exp_pauliword_to_gates
 from tangelo.toolboxes.ansatz_generator._qubit_mf import init_qmf_from_hf, get_qmf_circuit, purify_qmf_state
@@ -89,18 +87,20 @@ class QCC(Ansatz):
                  qmf_circuit=None, qmf_var_params=None, qubit_ham=None, qcc_tau_guess=1e-2,
                  deqcc_dtau_thresh=1e-3, max_qcc_gens=None, reference_state="HF"):
 
-        if not molecule and not (isinstance(molecule, SecondQuantizedMolecule) and isinstance(molecule, dict)):
-            raise ValueError("An instance of SecondQuantizedMolecule or a dict is required for "
-                             "initializing the self.__class__.__name__ ansatz class.")
+        if isinstance(molecule, dict) and not qubit_ham:
+            raise ValueError(f"An instance of SecondQuantizedMolecule or a dict"
+                " + qubit operator is required for initializing the "
+                f"{self.__class__.__name__} ansatz class.")
+
         self.molecule = molecule
-        if isinstance(self.molecule, (SecondQuantizedMolecule, SecondQuantizedDMETFragment)):
-            self.n_spinorbitals = self.molecule.n_active_sos
-            self.n_electrons = self.molecule.n_active_electrons
-            self.spin = self.molecule.spin
-        elif isinstance(self.molecule, dict):
+        if isinstance(self.molecule, dict):
             self.n_spinorbitals = self.molecule["n_spinorbitals"]
             self.n_electrons = self.molecule["n_electrons"]
             self.spin = self.molecule["spin"]
+        else:
+            self.n_spinorbitals = self.molecule.n_active_sos
+            self.n_electrons = self.molecule.n_active_electrons
+            self.spin = self.molecule.spin
 
         self.mapping = mapping
         self.up_then_down = up_then_down

--- a/tangelo/toolboxes/ansatz_generator/qcc.py
+++ b/tangelo/toolboxes/ansatz_generator/qcc.py
@@ -41,6 +41,7 @@ from tangelo.toolboxes.qubit_mappings.mapping_transform import get_qubit_number,
                                                                fermion_to_qubit_mapping
 from tangelo.linq import Circuit
 from tangelo import SecondQuantizedMolecule
+from tangelo.problem_decomposition.dmet.fragment import SecondQuantizedDMETFragment
 from tangelo.toolboxes.ansatz_generator.ansatz import Ansatz
 from tangelo.toolboxes.ansatz_generator.ansatz_utils import exp_pauliword_to_gates
 from tangelo.toolboxes.ansatz_generator._qubit_mf import init_qmf_from_hf, get_qmf_circuit, purify_qmf_state
@@ -55,9 +56,11 @@ class QCC(Ansatz):
     state is obtained using a RHF or ROHF Hamiltonian, respectively.
 
     Args:
-        molecule (SecondQuantizedMolecule or dict): The molecular system, which can
-            be passed as a SecondQuantizedMolecule or a dictionary with keys that
-            specify n_spinoribtals, n_electrons, and spin. Default, None.
+        molecule (SecondQuantizedMolecule, SecondQuantizedDMETFragment or dict):
+            The molecular system, which can be passed as a
+            SecondQuantizedMolecule/SecondQuantizedDMETFragment or a dictionary
+            with keys that specify n_spinoribtals, n_electrons, and spin.
+            Default, None.
         mapping (str): One of the supported qubit mapping identifiers. Default, "jw".
         up_then_down (bool): Change basis ordering putting all spin-up orbitals first,
             followed by all spin-down. Default, False.
@@ -90,7 +93,7 @@ class QCC(Ansatz):
             raise ValueError("An instance of SecondQuantizedMolecule or a dict is required for "
                              "initializing the self.__class__.__name__ ansatz class.")
         self.molecule = molecule
-        if isinstance(self.molecule, SecondQuantizedMolecule):
+        if isinstance(self.molecule, (SecondQuantizedMolecule, SecondQuantizedDMETFragment)):
             self.n_spinorbitals = self.molecule.n_active_sos
             self.n_electrons = self.molecule.n_active_electrons
             self.spin = self.molecule.spin


### PR DESCRIPTION
DMET was throwing an error when using VQE-QCC. The fix is to trick the `isinstance` function in the QCC ansatz. Also, the `self.solver_fragment_dict` is not defined before simulate when calling `quantum_fragment_data`: the error raised was not helpful. With the fix, the `RuntimeError` with our custom message is printed.