### PR TITLE
check for small value lcu

### DIFF
--- a/tangelo/toolboxes/circuits/lcu.py
+++ b/tangelo/toolboxes/circuits/lcu.py
@@ -322,6 +322,9 @@ def get_uprep_uselect(qu_op: QubitOperator, control: Union[int, List[int]] = Non
         if acoeff > 1.e-8:
             vector += [acoeff]
             unitaries += [QubitOperator(term, -coeff / acoeff)]
+        else:
+            vector += [0]
+            unitaries += [QubitOperator((), 1)]
 
     # create U_{prep} from sqrt of coefficients
     vector = np.array(vector)
@@ -382,7 +385,7 @@ def get_lcu_qubit_op_info(qu_op: QubitOperator()) -> Tuple[List[int], List[int],
     """
 
     max_qu_op = count_qubits(qu_op)
-    num_terms = len([coeff for coeff in qu_op.terms.values() if abs(coeff) > 1.e-8])
+    num_terms = len(qu_op.terms)
     alpha = sum([abs(v) for v in qu_op.terms.values()])
     n_qubits = math.ceil(math.log2(num_terms))
 

--- a/tangelo/toolboxes/circuits/lcu.py
+++ b/tangelo/toolboxes/circuits/lcu.py
@@ -319,8 +319,9 @@ def get_uprep_uselect(qu_op: QubitOperator, control: Union[int, List[int]] = Non
     max_qu_op = count_qubits(qu_op)
     for term, coeff in qu_op.terms.items():
         acoeff = np.abs(coeff)
-        vector += [acoeff]
-        unitaries += [QubitOperator(term, -coeff / acoeff)]
+        if acoeff > 1.e-8:
+            vector += [acoeff]
+            unitaries += [QubitOperator(term, -coeff / acoeff)]
 
     # create U_{prep} from sqrt of coefficients
     vector = np.array(vector)
@@ -381,7 +382,7 @@ def get_lcu_qubit_op_info(qu_op: QubitOperator()) -> Tuple[List[int], List[int],
     """
 
     max_qu_op = count_qubits(qu_op)
-    num_terms = len(qu_op.terms)
+    num_terms = len([coeff for coeff in qu_op.terms.values() if abs(coeff) > 1.e-8])
     alpha = sum([abs(v) for v in qu_op.terms.values()])
     n_qubits = math.ceil(math.log2(num_terms))
 


### PR DESCRIPTION
When multiplying qubit operators, zero coefficients can remain and this was not checked for in the LCU methods which caused nans.

For example
```python3
from tangelo.toolboxes.operators import QubitOperator
v1 = QubitOperator((), 1) + QubitOperator("X0", 0.5j)
v2 = QubitOperator((), 1) - QubitOperator("X0", 0.5j)
vdot = v1*v2
print([(term, coeff) for term, coeff in vdot.terms.items()])
```
outputs
```
[((), (1.25+0j)), (((0, 'X'),), 0j)]
```