### PR TITLE
added draw method to circuit

### DIFF
--- a/tangelo/linq/circuit.py
+++ b/tangelo/linq/circuit.py
@@ -20,7 +20,6 @@ characteristics (width, size ...).
 
 import copy
 from typing import List
-import warnings
 
 import numpy as np
 from cirq.contrib.svg import SVGCircuit
@@ -150,7 +149,6 @@ class Circuit:
         """Method to output a prettier version of the circuit for use in jupyter notebooks that uses cirq SVGCircuit"""
         # circular import
         from tangelo.linq.translator.translate_cirq import translate_c_to_cirq
-        warnings.filterwarnings("ignore", message=".*findfont.*")
         cirq_circ = translate_c_to_cirq(self)
         # Remove identity gates that are added in translate_c_to_cirq (to ensure all qubits are initialized) before drawing.
         cirq_circ.__delitem__(0)

--- a/tangelo/linq/circuit.py
+++ b/tangelo/linq/circuit.py
@@ -22,6 +22,7 @@ import copy
 from typing import List
 
 import numpy as np
+from cirq.contrib.svg import SVGCircuit
 
 from tangelo.linq import Gate
 
@@ -143,6 +144,15 @@ class Circuit:
         if any MEASURE gate was explicitly added by the user.
         """
         return "MEASURE" in self.counts
+
+    def draw(self):
+        """Method to output a prettier version of the circuit for use in jupyter notebooks that uses cirq SVGCircuit"""
+        # circular import
+        from tangelo.linq.translator.translate_cirq import translate_c_to_cirq
+        cirq_circ = translate_c_to_cirq(self)
+        # Remove identity gates that are added in translate_c_to_cirq (to ensure all qubits are initialized) before drawing.
+        cirq_circ.__delitem__(0)
+        return SVGCircuit(cirq_circ)
 
     def copy(self):
         """Return a deepcopy of circuit"""

--- a/tangelo/linq/circuit.py
+++ b/tangelo/linq/circuit.py
@@ -20,6 +20,7 @@ characteristics (width, size ...).
 
 import copy
 from typing import List
+import warnings
 
 import numpy as np
 from cirq.contrib.svg import SVGCircuit
@@ -149,6 +150,7 @@ class Circuit:
         """Method to output a prettier version of the circuit for use in jupyter notebooks that uses cirq SVGCircuit"""
         # circular import
         from tangelo.linq.translator.translate_cirq import translate_c_to_cirq
+        warnings.filterwarnings("ignore", message=".*findfont.*")
         cirq_circ = translate_c_to_cirq(self)
         # Remove identity gates that are added in translate_c_to_cirq (to ensure all qubits are initialized) before drawing.
         cirq_circ.__delitem__(0)


### PR DESCRIPTION
Uses cirq's SVGCircuit such that the following code
```python3
from tangelo.linq import Circuit, Gate

circ = Circuit([Gate("CRZ", target=0, control=[1,2], parameter=1),
                Gate("CNOT", target=0, control=1),
                Gate("RZ", target=0, parameter=0.3)])
circ.draw()
```
makes
[output.svg.pdf](https://github.com/goodchemistryco/Tangelo/files/10427016/output.svg.pdf)
