### PR TITLE
Cirq, qulacs, pennylane and projectq operator translation functions

### DIFF
--- a/tangelo/linq/target/target_cirq.py
+++ b/tangelo/linq/target/target_cirq.py
@@ -19,7 +19,7 @@ import numpy as np
 from tangelo.linq import Circuit
 from tangelo.linq.target.backend import Backend
 from tangelo.linq.translator import translate_circuit as translate_c
-from tangelo.linq.translator import get_cirq_gates
+from tangelo.linq.translator import translate_operator
 
 
 class CirqSimulator(Backend):
@@ -147,13 +147,9 @@ class CirqSimulator(Backend):
         """
 
         # Construct equivalent Pauli operator in Cirq format
-        GATE_CIRQ = get_cirq_gates()
         qubit_labels = self.cirq.LineQubit.range(n_qubits)
         qubit_map = {q: i for i, q in enumerate(qubit_labels)}
-        paulisum = 0.*self.cirq.PauliString(self.cirq.I(qubit_labels[0]))
-        for term, coef in qubit_operator.terms.items():
-            pauli_list = [GATE_CIRQ[pauli](qubit_labels[index]) for index, pauli in term]
-            paulisum += self.cirq.PauliString(pauli_list, coefficient=coef)
+        paulisum = translate_operator(qubit_operator, source="tangelo", target="cirq")
 
         # Compute expectation value using Cirq's features
         if self._noise_model:

--- a/tangelo/linq/target/target_qulacs.py
+++ b/tangelo/linq/target/target_qulacs.py
@@ -122,12 +122,14 @@ class QulacsSimulator(Backend):
                        for k, v in samples.items()}
         return (frequencies, python_statevector) if return_statevector else (frequencies, None)
 
-    def expectation_value_from_prepared_state(self, qubit_operator, prepared_state=None):
+    def expectation_value_from_prepared_state(self, qubit_operator, n_qubits, prepared_state=None):
         """ Compute an expectation value using a representation of the state
         using qulacs functionalities.
 
         Args:
             qubit_operator (QubitOperator): a qubit operator in tangelo format
+            n_qubits (int): Number of qubits (not used, to be consistent in the
+                Backend interface).
             prepared_state (np.array): a numpy array encoding the state (can be
                 a vector or a matrix). Default is None, in this case it is set
                 to the current state in the simulator object.

--- a/tangelo/linq/target/target_qulacs.py
+++ b/tangelo/linq/target/target_qulacs.py
@@ -21,6 +21,7 @@ import numpy as np
 from tangelo.linq import Circuit
 from tangelo.linq.target.backend import Backend
 from tangelo.linq.translator import translate_circuit as translate_c
+from tangelo.linq.translator import translate_operator
 
 
 class QulacsSimulator(Backend):
@@ -126,10 +127,7 @@ class QulacsSimulator(Backend):
         # TODO: This section previously used qulacs.quantum_operator.create_quantum_operator_from_openfermion_text but was changed
         # due to a memory leak. We can re-evaluate the implementation if/when Issue #303 (https://github.com/qulacs/qulacs/issues/303)
         # is fixed.
-        operator = self.qulacs.Observable(n_qubits)
-        for term, coef in qubit_operator.terms.items():
-            pauli_string = "".join(f" {op} {qu}" for qu, op in term)
-            operator.add_operator(coef, pauli_string)
+        operator = translate_operator(qubit_operator, source="tangelo", target="qulacs")
         return operator.get_expectation_value(self._current_state).real
 
     @staticmethod

--- a/tangelo/linq/target/target_qulacs.py
+++ b/tangelo/linq/target/target_qulacs.py
@@ -131,7 +131,7 @@ class QulacsSimulator(Backend):
             n_qubits (int): Number of qubits.
             prepared_state (np.array): a numpy array encoding the state (can be
                 a vector or a matrix). It is internally transformed into a
-                qulacs.QuantumState object. Default is None, in this case it is <
+                qulacs.QuantumState object. Default is None, in this case it is
                 set to the current state in the simulator object.
 
         Returns:

--- a/tangelo/linq/target/target_qulacs.py
+++ b/tangelo/linq/target/target_qulacs.py
@@ -128,17 +128,21 @@ class QulacsSimulator(Backend):
 
         Args:
             qubit_operator (QubitOperator): a qubit operator in tangelo format
-            n_qubits (int): Number of qubits (not used, to be consistent with
-                the call from the Backend class).
+            n_qubits (int): Number of qubits.
             prepared_state (np.array): a numpy array encoding the state (can be
-                a vector or a matrix). Default is None, in this case it is set
-                to the current state in the simulator object.
+                a vector or a matrix). It is internally transformed into a
+                qulacs.QuantumState object. Default is None, in this case it is <
+                set to the current state in the simulator object.
 
         Returns:
             float64 : the expectation value of the qubit operator w.r.t the input state
         """
         if prepared_state is None:
             prepared_state = self._current_state
+        else:
+            qulacs_state = self.qulacs.QuantumState(n_qubits)
+            qulacs_state.load(prepared_state)
+            prepared_state = qulacs_state
 
         operator = translate_operator(qubit_operator, source="tangelo", target="qulacs")
         return operator.get_expectation_value(prepared_state).real

--- a/tangelo/linq/target/target_qulacs.py
+++ b/tangelo/linq/target/target_qulacs.py
@@ -128,8 +128,8 @@ class QulacsSimulator(Backend):
 
         Args:
             qubit_operator (QubitOperator): a qubit operator in tangelo format
-            n_qubits (int): Number of qubits (not used, to be consistent in the
-                Backend interface).
+            n_qubits (int): Number of qubits (not used, to be consistent with
+                the call from the Backend class).
             prepared_state (np.array): a numpy array encoding the state (can be
                 a vector or a matrix). Default is None, in this case it is set
                 to the current state in the simulator object.

--- a/tangelo/linq/target/target_qulacs.py
+++ b/tangelo/linq/target/target_qulacs.py
@@ -122,13 +122,24 @@ class QulacsSimulator(Backend):
                        for k, v in samples.items()}
         return (frequencies, python_statevector) if return_statevector else (frequencies, None)
 
-    def expectation_value_from_prepared_state(self, qubit_operator, n_qubits, prepared_state):
+    def expectation_value_from_prepared_state(self, qubit_operator, prepared_state=None):
+        """ Compute an expectation value using a representation of the state
+        using qulacs functionalities.
 
-        # TODO: This section previously used qulacs.quantum_operator.create_quantum_operator_from_openfermion_text but was changed
-        # due to a memory leak. We can re-evaluate the implementation if/when Issue #303 (https://github.com/qulacs/qulacs/issues/303)
-        # is fixed.
+        Args:
+            qubit_operator (QubitOperator): a qubit operator in tangelo format
+            prepared_state (np.array): a numpy array encoding the state (can be
+                a vector or a matrix). Default is None, in this case it is set
+                to the current state in the simulator object.
+
+        Returns:
+            float64 : the expectation value of the qubit operator w.r.t the input state
+        """
+        if prepared_state is None:
+            prepared_state = self._current_state
+
         operator = translate_operator(qubit_operator, source="tangelo", target="qulacs")
-        return operator.get_expectation_value(self._current_state).real
+        return operator.get_expectation_value(prepared_state).real
 
     @staticmethod
     def backend_info():

--- a/tangelo/linq/tests/test_translator_qubitop.py
+++ b/tangelo/linq/tests/test_translator_qubitop.py
@@ -28,7 +28,7 @@ from tangelo.toolboxes.operators import QubitOperator
 # For openfermion.load_operator function.
 pwd_this_test = os.path.dirname(os.path.abspath(__file__))
 
-tangelo_op = QubitOperator("X0 Y1 Z2", 1.)
+tangelo_op = QubitOperator("X0 Y1 Z2", 2.)
 
 
 class TranslateOperatorTest(unittest.TestCase):
@@ -50,7 +50,7 @@ class TranslateOperatorTest(unittest.TestCase):
         """Test translation from a qiskit to a tangelo operator."""
 
         from qiskit.opflow.primitive_ops import PauliSumOp
-        qiskit_op = PauliSumOp.from_list([("ZYX", 1.)])
+        qiskit_op = PauliSumOp.from_list([("ZYX", 2.)])
 
         test_op = translate_operator(qiskit_op, source="qiskit", target="tangelo")
         self.assertEqual(test_op, tangelo_op)
@@ -60,7 +60,7 @@ class TranslateOperatorTest(unittest.TestCase):
         """Test translation from a tangelo to a qiskit operator."""
 
         from qiskit.opflow.primitive_ops import PauliSumOp
-        qiskit_op = PauliSumOp.from_list([("ZYX", 1.)])
+        qiskit_op = PauliSumOp.from_list([("ZYX", 2.)])
 
         test_op = translate_operator(tangelo_op, source="tangelo", target="qiskit")
         self.assertEqual(qiskit_op, test_op)
@@ -72,7 +72,7 @@ class TranslateOperatorTest(unittest.TestCase):
         from cirq import PauliSum, PauliString, LineQubit, X, Y, Z
         qubit_a, qubit_b, qubit_c = LineQubit.range(3)
         cirq_op = PauliSum.from_pauli_strings([
-            PauliString(1., X(qubit_a), Y(qubit_b), Z(qubit_c))
+            PauliString(2., X(qubit_a), Y(qubit_b), Z(qubit_c))
         ])
 
         test_op = translate_operator(cirq_op, source="cirq", target="tangelo")
@@ -85,7 +85,7 @@ class TranslateOperatorTest(unittest.TestCase):
         from cirq import PauliSum, PauliString, LineQubit, X, Y, Z
         qubit_a, qubit_b, qubit_c = LineQubit.range(3)
         cirq_op = PauliSum.from_pauli_strings([
-            PauliString(1., X(qubit_a), Y(qubit_b), Z(qubit_c))
+            PauliString(2., X(qubit_a), Y(qubit_b), Z(qubit_c))
         ])
 
         test_op = translate_operator(tangelo_op, source="tangelo", target="cirq")
@@ -97,7 +97,7 @@ class TranslateOperatorTest(unittest.TestCase):
 
         from qulacs import GeneralQuantumOperator
         qulacs_op = GeneralQuantumOperator(3)
-        qulacs_op.add_operator(1., "X 0 Y 1 Z 2")
+        qulacs_op.add_operator(2., "X 0 Y 1 Z 2")
 
         test_op = translate_operator(qulacs_op, source="qulacs", target="tangelo")
         self.assertEqual(test_op, tangelo_op)
@@ -108,7 +108,7 @@ class TranslateOperatorTest(unittest.TestCase):
 
         from qulacs import GeneralQuantumOperator
         qulacs_op = GeneralQuantumOperator(3)
-        qulacs_op.add_operator(1., "X 0 Y 1 Z 2")
+        qulacs_op.add_operator(2., "X 0 Y 1 Z 2")
 
         test_op = translate_operator(tangelo_op, source="tangelo", target="qulacs")
 
@@ -123,7 +123,7 @@ class TranslateOperatorTest(unittest.TestCase):
         """Test translation from a pennylane to a tangelo operator."""
 
         import pennylane as qml
-        coeffs = [1.]
+        coeffs = [2.]
         obs = [qml.PauliX(0) @ qml.PauliY(1) @ qml.PauliZ(2)]
         pennylane_H = qml.Hamiltonian(coeffs, obs)
 
@@ -135,7 +135,7 @@ class TranslateOperatorTest(unittest.TestCase):
         """Test translation from a tangelo to a pennylane operator."""
 
         import pennylane as qml
-        coeffs = [1.]
+        coeffs = [2.]
         obs = [qml.PauliX(0) @ qml.PauliY(1) @ qml.PauliZ(2)]
         pennylane_H = qml.Hamiltonian(coeffs, obs)
 
@@ -149,7 +149,7 @@ class TranslateOperatorTest(unittest.TestCase):
         """Test translation from a projectq to a tangelo operator."""
 
         from projectq.ops import QubitOperator as ProjectQQubitOperator
-        projectq_op = ProjectQQubitOperator("X0 Y1 Z2", 1.)
+        projectq_op = ProjectQQubitOperator("X0 Y1 Z2", 2.)
 
         test_op = translate_operator(projectq_op, source="projectq", target="tangelo")
 
@@ -160,7 +160,7 @@ class TranslateOperatorTest(unittest.TestCase):
         """Test translation from a tangelo to a projectq operator."""
 
         from projectq.ops import QubitOperator as ProjectQQubitOperator
-        projectq_op = ProjectQQubitOperator("X0 Y1 Z2", 1.)
+        projectq_op = ProjectQQubitOperator("X0 Y1 Z2", 2.)
 
         test_op = translate_operator(tangelo_op, source="tangelo", target="projectq")
 

--- a/tangelo/linq/tests/test_translator_qubitop.py
+++ b/tangelo/linq/tests/test_translator_qubitop.py
@@ -65,6 +65,107 @@ class TranslateOperatorTest(unittest.TestCase):
         test_op = translate_operator(tangelo_op, source="tangelo", target="qiskit")
         self.assertEqual(qiskit_op, test_op)
 
+    @unittest.skipIf("cirq" not in installed_backends, "Test Skipped: Cirq not available \n")
+    def test_cirq_to_tangelo(self):
+        """Test translation from a cirq to a tangelo operator."""
+
+        from cirq import PauliSum, PauliString, LineQubit, X, Y, Z
+        qubit_a, qubit_b, qubit_c = LineQubit.range(3)
+        cirq_op = PauliSum.from_pauli_strings([
+            PauliString(1., X(qubit_a), Y(qubit_b), Z(qubit_c))
+        ])
+
+        test_op = translate_operator(cirq_op, source="cirq", target="tangelo")
+        self.assertEqual(test_op, tangelo_op)
+
+    @unittest.skipIf("cirq" not in installed_backends, "Test Skipped: Cirq not available \n")
+    def test_tangelo_to_cirq(self):
+        """Test translation from a tangelo to a cirq operator."""
+
+        from cirq import PauliSum, PauliString, LineQubit, X, Y, Z
+        qubit_a, qubit_b, qubit_c = LineQubit.range(3)
+        cirq_op = PauliSum.from_pauli_strings([
+            PauliString(1., X(qubit_a), Y(qubit_b), Z(qubit_c))
+        ])
+
+        test_op = translate_operator(tangelo_op, source="tangelo", target="cirq")
+        self.assertEqual(cirq_op, test_op)
+
+    @unittest.skipIf("qulacs" not in installed_backends, "Test Skipped: qulacs not available \n")
+    def test_qulacs_to_tangelo(self):
+        """Test translation from a qulacs to a tangelo operator."""
+
+        from qulacs import GeneralQuantumOperator
+        qulacs_op = GeneralQuantumOperator(3)
+        qulacs_op.add_operator(1., "X 0 Y 1 Z 2")
+
+        test_op = translate_operator(qulacs_op, source="qulacs", target="tangelo")
+        self.assertEqual(test_op, tangelo_op)
+
+    @unittest.skipIf("qulacs" not in installed_backends, "Test Skipped: qulacs not available \n")
+    def test_tangelo_to_qulacs(self):
+        """Test translation from a tangelo to a qulacs operator."""
+
+        from qulacs import GeneralQuantumOperator
+        qulacs_op = GeneralQuantumOperator(3)
+        qulacs_op.add_operator(1., "X 0 Y 1 Z 2")
+
+        test_op = translate_operator(tangelo_op, source="tangelo", target="qulacs")
+
+        # __eq__ method is not implemented for GeneralQuantumOperator. It is
+        # checking the addresses in memory when comparing 2 qulacs objects.
+        self.assertEqual(qulacs_op.get_term_count(), test_op.get_term_count())
+        self.assertEqual(qulacs_op.get_term(0).get_coef(), test_op.get_term(0).get_coef())
+        self.assertEqual(qulacs_op.get_term(0).get_pauli_string(), test_op.get_term(0).get_pauli_string())
+
+    @unittest.skipIf("pennylane" not in installed_backends, "Test Skipped: Pennylane not available \n")
+    def test_pennylane_to_tangelo(self):
+        """Test translation from a pennylane to a tangelo operator."""
+
+        import pennylane as qml
+        coeffs = [1.]
+        obs = [qml.PauliX(0) @ qml.PauliY(1) @ qml.PauliZ(2)]
+        pennylane_H = qml.Hamiltonian(coeffs, obs)
+
+        test_op = translate_operator(pennylane_H, source="pennylane", target="tangelo")
+        self.assertEqual(test_op, tangelo_op)
+
+    @unittest.skipIf("pennylane" not in installed_backends, "Test Skipped: Pennylane not available \n")
+    def test_tangelo_to_pennylane(self):
+        """Test translation from a tangelo to a pennylane operator."""
+
+        import pennylane as qml
+        coeffs = [1.]
+        obs = [qml.PauliX(0) @ qml.PauliY(1) @ qml.PauliZ(2)]
+        pennylane_H = qml.Hamiltonian(coeffs, obs)
+
+        test_op = translate_operator(tangelo_op, source="tangelo", target="pennylane")
+
+        # __eq__ method not implemented in pennylane.Hamiltonian.
+        self.assertTrue(pennylane_H.compare(test_op))
+
+    @unittest.skipIf("projectq" not in installed_backends, "Test Skipped: ProjectQ not available \n")
+    def test_projectq_to_tangelo(self):
+        """Test translation from a projectq to a tangelo operator."""
+
+        from projectq.ops import QubitOperator as ProjectQQubitOperator
+        projectq_op = ProjectQQubitOperator("X0 Y1 Z2", 1.)
+
+        test_op = translate_operator(projectq_op, source="projectq", target="tangelo")
+
+        self.assertEqual(test_op, tangelo_op)
+
+    @unittest.skipIf("projectq" not in installed_backends, "Test Skipped: ProjectQ not available \n")
+    def test_tangelo_to_projectq(self):
+        """Test translation from a tangelo to a projectq operator."""
+
+        from projectq.ops import QubitOperator as ProjectQQubitOperator
+        projectq_op = ProjectQQubitOperator("X0 Y1 Z2", 1.)
+
+        test_op = translate_operator(tangelo_op, source="tangelo", target="projectq")
+
+        self.assertEqual(projectq_op, test_op)
+
     @unittest.skipIf("qiskit" not in installed_backends, "Test Skipped: Qiskit not available \n")
     def test_tangelo_to_qiskit_H2_eigenvalues(self):
         """Test eigenvalues resulting from a tangelo to qiskit translation."""

--- a/tangelo/linq/translator/translate_cirq.py
+++ b/tangelo/linq/translator/translate_cirq.py
@@ -24,6 +24,7 @@ necessary to account for:
 
 from math import pi
 
+from tangelo.toolboxes.operators import QubitOperator
 from tangelo.helpers import deprecated
 
 
@@ -164,3 +165,52 @@ def translate_c_to_cirq(source_circuit, noise_model=None, save_measurements=Fals
                     target_circuit.append(depo(*depo_list))  # gates targeted
 
     return target_circuit
+
+
+def translate_op_to_cirq(qubit_operator):
+    """Helper function to translate a Tangelo QubitOperator to a cirq linear
+    combination of Pauli strings.
+
+    Args:
+        qubit_operator (tangelo.toolboxes.operators.QubitOperator): Self-explanatory.
+
+    Returns:
+        (cirq.ops.linear_combinations.PauliSum): Cirq summation of Pauli strings.
+    """
+    from openfermion.transforms import qubit_operator_to_pauli_sum
+
+    return qubit_operator_to_pauli_sum(qubit_operator)
+
+
+def translate_op_from_cirq(qubit_operator):
+    """Helper function to translate a cirq linear combination of Pauli strings
+    to a Tangelo QubitOperator.
+
+    Args:
+        qubit_operator (cirq.ops.linear_combinations.PauliSum): Self-explanatory.
+
+    Returns:
+        (tangelo.toolboxes.operators.QubitOperator): Tangelo qubit operator.
+    """
+    import cirq
+
+    # Create a dictionary to append all terms at once.
+    tangelo_op = QubitOperator()
+
+    cirq_pauli_to_string = {cirq.X: "X", cirq.Y: "Y", cirq.Z: "Z"}
+
+    for pauli_word in qubit_operator:
+
+        term_string = ""
+        for line_qubit, cirq_pauli in pauli_word.items():
+
+            term_string += f"{cirq_pauli_to_string[cirq_pauli]}{line_qubit.x} "
+
+        term_string.strip()
+
+        tangelo_op += QubitOperator(term_string.strip(), pauli_word.coefficient)
+
+    # Clean the QubitOperator.
+    tangelo_op.compress()
+
+    return tangelo_op

--- a/tangelo/linq/translator/translate_cirq.py
+++ b/tangelo/linq/translator/translate_cirq.py
@@ -167,12 +167,13 @@ def translate_c_to_cirq(source_circuit, noise_model=None, save_measurements=Fals
     return target_circuit
 
 
-def translate_op_to_cirq(qubit_operator):
+def translate_op_to_cirq(qubit_operator, n_qubits=None):
     """Helper function to translate a Tangelo QubitOperator to a cirq linear
     combination of Pauli strings.
 
     Args:
         qubit_operator (tangelo.toolboxes.operators.QubitOperator): Self-explanatory.
+        n_qubits (int): Number of qubits, ignored.
 
     Returns:
         (cirq.ops.linear_combinations.PauliSum): Cirq summation of Pauli strings.

--- a/tangelo/linq/translator/translate_cirq.py
+++ b/tangelo/linq/translator/translate_cirq.py
@@ -167,13 +167,12 @@ def translate_c_to_cirq(source_circuit, noise_model=None, save_measurements=Fals
     return target_circuit
 
 
-def translate_op_to_cirq(qubit_operator, n_qubits=None):
+def translate_op_to_cirq(qubit_operator):
     """Helper function to translate a Tangelo QubitOperator to a cirq linear
     combination of Pauli strings.
 
     Args:
         qubit_operator (tangelo.toolboxes.operators.QubitOperator): Self-explanatory.
-        n_qubits (int): Number of qubits, ignored.
 
     Returns:
         (cirq.ops.linear_combinations.PauliSum): Cirq summation of Pauli strings.

--- a/tangelo/linq/translator/translate_cirq.py
+++ b/tangelo/linq/translator/translate_cirq.py
@@ -203,10 +203,7 @@ def translate_op_from_cirq(qubit_operator):
 
         term_string = ""
         for line_qubit, cirq_pauli in pauli_word.items():
-
             term_string += f"{cirq_pauli_to_string[cirq_pauli]}{line_qubit.x} "
-
-        term_string.strip()
 
         tangelo_op += QubitOperator(term_string.strip(), pauli_word.coefficient)
 

--- a/tangelo/linq/translator/translate_cirq.py
+++ b/tangelo/linq/translator/translate_cirq.py
@@ -207,7 +207,4 @@ def translate_op_from_cirq(qubit_operator):
 
         tangelo_op += QubitOperator(term_string.strip(), pauli_word.coefficient)
 
-    # Clean the QubitOperator.
-    tangelo_op.compress()
-
     return tangelo_op

--- a/tangelo/linq/translator/translate_cirq.py
+++ b/tangelo/linq/translator/translate_cirq.py
@@ -194,7 +194,6 @@ def translate_op_from_cirq(qubit_operator):
     """
     import cirq
 
-    # Create a dictionary to append all terms at once.
     tangelo_op = QubitOperator()
 
     cirq_pauli_to_string = {cirq.X: "X", cirq.Y: "Y", cirq.Z: "Z"}

--- a/tangelo/linq/translator/translate_pennylane.py
+++ b/tangelo/linq/translator/translate_pennylane.py
@@ -102,13 +102,14 @@ def translate_c_to_pennylane(source_circuit):
     return target_circuit
 
 
-def translate_op_to_pennylane(qubit_operator):
+def translate_op_to_pennylane(qubit_operator, n_qubits=None):
     """Helper function to translate a Tangelo QubitOperator to a pennylane
     Hamiltonian operator. For the pennylane package, all the coefficients must
     be real.
 
     Args:
         qubit_operator (tangelo.toolboxes.operators.QubitOperator): Self-explanatory.
+        n_qubits (int): Number of qubits, ignored.
 
     Returns:
         (pennylane.ops.qubit.hamiltonian.Hamiltonian): Pennylane Hamiltonian.

--- a/tangelo/linq/translator/translate_pennylane.py
+++ b/tangelo/linq/translator/translate_pennylane.py
@@ -24,6 +24,8 @@ necessary to account for:
 
 from math import pi
 
+from tangelo.toolboxes.operators import QubitOperator
+
 
 def get_pennylane_gates():
     """Map gate name of the abstract format to the equivalent methods of the
@@ -127,5 +129,9 @@ def translate_op_from_pennylane(qubit_operator):
         (tangelo.toolboxes.operators.QubitOperator): Tangelo qubit operator.
     """
     from pennylane.qchem.convert import _pennylane_to_openfermion
+    of_op = _pennylane_to_openfermion(qubit_operator.coeffs, qubit_operator.ops)
 
-    return _pennylane_to_openfermion(qubit_operator.coeffs, qubit_operator.ops)
+    tangelo_op = QubitOperator()
+    tangelo_op.terms = of_op.terms
+
+    return tangelo_op

--- a/tangelo/linq/translator/translate_pennylane.py
+++ b/tangelo/linq/translator/translate_pennylane.py
@@ -102,14 +102,13 @@ def translate_c_to_pennylane(source_circuit):
     return target_circuit
 
 
-def translate_op_to_pennylane(qubit_operator, n_qubits=None):
+def translate_op_to_pennylane(qubit_operator):
     """Helper function to translate a Tangelo QubitOperator to a pennylane
     Hamiltonian operator. For the pennylane package, all the coefficients must
     be real.
 
     Args:
         qubit_operator (tangelo.toolboxes.operators.QubitOperator): Self-explanatory.
-        n_qubits (int): Number of qubits, ignored.
 
     Returns:
         (pennylane.ops.qubit.hamiltonian.Hamiltonian): Pennylane Hamiltonian.

--- a/tangelo/linq/translator/translate_pennylane.py
+++ b/tangelo/linq/translator/translate_pennylane.py
@@ -98,3 +98,34 @@ def translate_c_to_pennylane(source_circuit):
             raise ValueError(f"Gate '{gate.name}' not supported for translation to pennylane")
 
     return target_circuit
+
+
+def translate_op_to_pennylane(qubit_operator):
+    """Helper function to translate a Tangelo QubitOperator to a pennylane
+    Hamiltonian operator. For the pennylane package, all the coefficients must
+    be real.
+
+    Args:
+        qubit_operator (tangelo.toolboxes.operators.QubitOperator): Self-explanatory.
+
+    Returns:
+        (pennylane.ops.qubit.hamiltonian.Hamiltonian): Pennylane Hamiltonian.
+    """
+    from pennylane import import_operator
+
+    return import_operator(qubit_operator, format="openfermion")
+
+
+def translate_op_from_pennylane(qubit_operator):
+    """Helper function to translate pennylane Hamiltonian (only real
+    coefficients) to a Tangelo QubitOperator.
+
+    Args:
+        qubit_operator (pennylane.ops.qubit.hamiltonian.Hamiltonian): Self-explanatory.
+
+    Returns:
+        (tangelo.toolboxes.operators.QubitOperator): Tangelo qubit operator.
+    """
+    from pennylane.qchem.convert import _pennylane_to_openfermion
+
+    return _pennylane_to_openfermion(qubit_operator.coeffs, qubit_operator.ops)

--- a/tangelo/linq/translator/translate_projectq.py
+++ b/tangelo/linq/translator/translate_projectq.py
@@ -161,12 +161,13 @@ def translate_c_from_projectq(projectq_str):
     return abs_circ
 
 
-def translate_op_to_projectq(qubit_operator):
+def translate_op_to_projectq(qubit_operator, n_qubits=None):
     """Helper function to translate a Tangelo QubitOperator to a projectq qubit
     operator.
 
     Args:
         qubit_operator (tangelo.toolboxes.operators.QubitOperator): Self-explanatory.
+        n_qubits (int): Number of qubits, ignored.
 
     Returns:
         (projectq.ops.QubitOperator): ProjectQ QubitOperator.

--- a/tangelo/linq/translator/translate_projectq.py
+++ b/tangelo/linq/translator/translate_projectq.py
@@ -25,6 +25,7 @@ necessary to account for:
 import re
 
 from tangelo.linq import Gate, Circuit
+from tangelo.toolboxes.operators import QubitOperator
 from tangelo.helpers import deprecated
 
 
@@ -158,3 +159,38 @@ def translate_c_from_projectq(projectq_str):
         abs_circ.add_gate(gate)
 
     return abs_circ
+
+
+def translate_op_to_projectq(qubit_operator):
+    """Helper function to translate a Tangelo QubitOperator to a projectq qubit
+    operator.
+
+    Args:
+        qubit_operator (tangelo.toolboxes.operators.QubitOperator): Self-explanatory.
+
+    Returns:
+        (projectq.ops.QubitOperator): ProjectQ QubitOperator.
+    """
+    from projectq.ops import QubitOperator as projectqQubitOperator
+
+    projectq_quop = projectqQubitOperator()
+    projectq_quop.terms = qubit_operator.terms
+
+    return projectq_quop
+
+
+def translate_op_from_projectq(qubit_operator):
+    """Helper function to translate projectq qubit operator to a Tangelo
+    QubitOperator.
+
+    Args:
+        qubit_operator (projectq.ops.QubitOperator): Self-explanatory.
+
+    Returns:
+        (tangelo.toolboxes.operators.QubitOperator): Tangelo qubit operator.
+    """
+
+    tangelo_op = QubitOperator()
+    tangelo_op.terms = qubit_operator.terms
+
+    return tangelo_op

--- a/tangelo/linq/translator/translate_projectq.py
+++ b/tangelo/linq/translator/translate_projectq.py
@@ -161,13 +161,12 @@ def translate_c_from_projectq(projectq_str):
     return abs_circ
 
 
-def translate_op_to_projectq(qubit_operator, n_qubits=None):
+def translate_op_to_projectq(qubit_operator):
     """Helper function to translate a Tangelo QubitOperator to a projectq qubit
     operator.
 
     Args:
         qubit_operator (tangelo.toolboxes.operators.QubitOperator): Self-explanatory.
-        n_qubits (int): Number of qubits, ignored.
 
     Returns:
         (projectq.ops.QubitOperator): ProjectQ QubitOperator.

--- a/tangelo/linq/translator/translate_projectq.py
+++ b/tangelo/linq/translator/translate_projectq.py
@@ -171,9 +171,9 @@ def translate_op_to_projectq(qubit_operator):
     Returns:
         (projectq.ops.QubitOperator): ProjectQ QubitOperator.
     """
-    from projectq.ops import QubitOperator as projectqQubitOperator
+    from projectq.ops import QubitOperator as ProjectQQubitOperator
 
-    projectq_quop = projectqQubitOperator()
+    projectq_quop = ProjectQQubitOperator()
     projectq_quop.terms = qubit_operator.terms
 
     return projectq_quop

--- a/tangelo/linq/translator/translate_qiskit.py
+++ b/tangelo/linq/translator/translate_qiskit.py
@@ -219,7 +219,4 @@ def translate_op_from_qiskit(qubit_operator):
     tangelo_op = QubitOperator()
     tangelo_op.terms = terms_dict
 
-    # Clean the QubitOperator.
-    tangelo_op.compress()
-
     return tangelo_op

--- a/tangelo/linq/translator/translate_qiskit.py
+++ b/tangelo/linq/translator/translate_qiskit.py
@@ -213,7 +213,7 @@ def translate_op_from_qiskit(qubit_operator):
         # Inversion of the string because of qiskit ordering.
         term_string = pauli_word.to_pauli_op().primitive.to_label()[::-1]
         term_tuple = pauli_string_to_of(term_string)
-        terms_dict[tuple(term_tuple)] = pauli_word.coeff
+        terms_dict[tuple(term_tuple)] = complex(pauli_word.coeffs)
 
     # Create and copy the information into a new QubitOperator.
     tangelo_op = QubitOperator()

--- a/tangelo/linq/translator/translate_qubitop.py
+++ b/tangelo/linq/translator/translate_qubitop.py
@@ -19,19 +19,23 @@ from tangelo.linq.translator.translate_qiskit import translate_op_from_qiskit, t
 from tangelo.linq.translator.translate_cirq import translate_op_from_cirq, translate_op_to_cirq
 from tangelo.linq.translator.translate_qulacs import translate_op_from_qulacs, translate_op_to_qulacs
 from tangelo.linq.translator.translate_pennylane import translate_op_from_pennylane, translate_op_to_pennylane
+from tangelo.linq.translator.translate_projectq import translate_op_from_projectq, translate_op_to_projectq
+
 
 FROM_TANGELO = {
     "qiskit": translate_op_to_qiskit,
     "cirq": translate_op_to_cirq,
     "qulacs": translate_op_to_qulacs,
-    "pennylane": translate_op_to_pennylane
+    "pennylane": translate_op_to_pennylane,
+    "projectq": translate_op_to_projectq
 }
 
 TO_TANGELO = {
     "qiskit": translate_op_from_qiskit,
     "cirq": translate_op_from_cirq,
     "qulacs": translate_op_from_qulacs,
-    "pennylane": translate_op_from_pennylane
+    "pennylane": translate_op_from_pennylane,
+    "projectq": translate_op_from_projectq
 }
 
 

--- a/tangelo/linq/translator/translate_qubitop.py
+++ b/tangelo/linq/translator/translate_qubitop.py
@@ -16,14 +16,17 @@
 
 from tangelo.toolboxes.operators import count_qubits
 from tangelo.linq.translator.translate_qiskit import translate_op_from_qiskit, translate_op_to_qiskit
+from tangelo.linq.translator.translate_cirq import translate_op_from_cirq, translate_op_to_cirq
 
 
 FROM_TANGELO = {
-    "qiskit": translate_op_to_qiskit
+    "qiskit": translate_op_to_qiskit,
+    "cirq": translate_op_to_cirq
 }
 
 TO_TANGELO = {
-    "qiskit": translate_op_from_qiskit
+    "qiskit": translate_op_from_qiskit,
+    "cirq": translate_op_from_cirq
 }
 
 

--- a/tangelo/linq/translator/translate_qubitop.py
+++ b/tangelo/linq/translator/translate_qubitop.py
@@ -17,16 +17,19 @@
 from tangelo.toolboxes.operators import count_qubits
 from tangelo.linq.translator.translate_qiskit import translate_op_from_qiskit, translate_op_to_qiskit
 from tangelo.linq.translator.translate_cirq import translate_op_from_cirq, translate_op_to_cirq
+from tangelo.linq.translator.translate_qulacs import translate_op_from_qulacs, translate_op_to_qulacs
 
 
 FROM_TANGELO = {
     "qiskit": translate_op_to_qiskit,
-    "cirq": translate_op_to_cirq
+    "cirq": translate_op_to_cirq,
+    "qulacs": translate_op_to_qulacs
 }
 
 TO_TANGELO = {
     "qiskit": translate_op_from_qiskit,
-    "cirq": translate_op_from_cirq
+    "cirq": translate_op_from_cirq,
+    "qulacs": translate_op_from_qulacs
 }
 
 

--- a/tangelo/linq/translator/translate_qubitop.py
+++ b/tangelo/linq/translator/translate_qubitop.py
@@ -47,9 +47,9 @@ def translate_operator(qubit_operator, source, target, n_qubits=None):
         qubit_operator (source format): Self-explanatory.
         source (string): Identifier for the source format.
         target (string): Identifier for the target format.
-        n_qubits (int): Number of qubits relevant to the operator. It is
-            used for target="qiskit", and can be automatically computed from the
-            count_qubits function. For the other targets, it is ignored.
+        n_qubits (int): Number of qubits relevant to the operator. Not used by
+            all format conversion functions, will be computed automatically if
+            not specified.
 
     Returns:
         (operator in target format): Translated qubit operator.

--- a/tangelo/linq/translator/translate_qubitop.py
+++ b/tangelo/linq/translator/translate_qubitop.py
@@ -14,8 +14,6 @@
 
 """Module to convert qubit operators to different formats."""
 
-import warnings
-
 from tangelo.toolboxes.operators import count_qubits, QubitOperator
 from tangelo.linq.translator.translate_qiskit import translate_op_from_qiskit, translate_op_to_qiskit
 from tangelo.linq.translator.translate_cirq import translate_op_from_cirq, translate_op_to_cirq
@@ -49,7 +47,9 @@ def translate_operator(qubit_operator, source, target, n_qubits=None):
         qubit_operator (source format): Self-explanatory.
         source (string): Identifier for the source format.
         target (string): Identifier for the target format.
-        n_qubits (int): Number of qubits relevant to the operator.
+        n_qubits (int): Number of qubits relevant to the operator. It is
+            used for target="qiskit", and can be automatically computed from the
+            count_qubits function. For the other targets, it is ignored.
 
     Returns:
         (operator in target format): Translated qubit operator.
@@ -60,19 +60,25 @@ def translate_operator(qubit_operator, source, target, n_qubits=None):
 
     if source == target:
         return qubit_operator
+
     if source != "tangelo":
         if source not in TO_TANGELO:
             raise NotImplementedError(f"Qubit operator conversion from {source} to {target} is not supported.")
         qubit_operator = TO_TANGELO[source](qubit_operator)
+
     if target != "tangelo":
         if target not in FROM_TANGELO:
             raise NotImplementedError(f"Qubit operator conversion from {source} to {target} is not supported.")
 
-        if n_qubits is not None and target in {"qulacs", "projectq", "pennylane", "cirq"}:
-            warnings.warn(f"The qubit operator translation from {source} to "
-                f"{target} ignores the n_qubits provided.")
-
-        n_qubits = count_qubits(qubit_operator) if n_qubits is None else n_qubits
-        qubit_operator = FROM_TANGELO[target](qubit_operator, n_qubits)
+        # For translation functions that need an explicit number of qubits.
+        if target in {"qiskit"}:
+            # The count_qubits function has no way to detect the number of
+            # qubits when an operator is only a tensor product of I.
+            if qubit_operator == QubitOperator((), qubit_operator.constant):
+                raise ValueError("The number of qubits (n_qubits) must be provided.")
+            n_qubits = count_qubits(qubit_operator) if n_qubits is None else n_qubits
+            qubit_operator = FROM_TANGELO[target](qubit_operator, n_qubits)
+        else:
+            qubit_operator = FROM_TANGELO[target](qubit_operator)
 
     return qubit_operator

--- a/tangelo/linq/translator/translate_qubitop.py
+++ b/tangelo/linq/translator/translate_qubitop.py
@@ -57,6 +57,9 @@ def translate_operator(qubit_operator, source, target, n_qubits=None):
         if target not in FROM_TANGELO:
             raise NotImplementedError(f"Qubit operator conversion from {source} to {target} is not supported.")
         n_qubits = count_qubits(qubit_operator) if n_qubits is None else n_qubits
-        qubit_operator = FROM_TANGELO[target](qubit_operator, n_qubits)
+        try:
+            qubit_operator = FROM_TANGELO[target](qubit_operator, n_qubits)
+        except TypeError:
+            qubit_operator = FROM_TANGELO[target](qubit_operator)
 
     return qubit_operator

--- a/tangelo/linq/translator/translate_qubitop.py
+++ b/tangelo/linq/translator/translate_qubitop.py
@@ -56,6 +56,8 @@ def translate_operator(qubit_operator, source, target, n_qubits=None):
         if source not in TO_TANGELO:
             raise NotImplementedError(f"Qubit operator conversion from {source} to {target} is not supported.")
         qubit_operator = TO_TANGELO[source](qubit_operator)
+        # Clean the very small terms.
+        qubit_operator.compress()
     if target != "tangelo":
         if target not in FROM_TANGELO:
             raise NotImplementedError(f"Qubit operator conversion from {source} to {target} is not supported.")

--- a/tangelo/linq/translator/translate_qubitop.py
+++ b/tangelo/linq/translator/translate_qubitop.py
@@ -18,18 +18,20 @@ from tangelo.toolboxes.operators import count_qubits
 from tangelo.linq.translator.translate_qiskit import translate_op_from_qiskit, translate_op_to_qiskit
 from tangelo.linq.translator.translate_cirq import translate_op_from_cirq, translate_op_to_cirq
 from tangelo.linq.translator.translate_qulacs import translate_op_from_qulacs, translate_op_to_qulacs
-
+from tangelo.linq.translator.translate_pennylane import translate_op_from_pennylane, translate_op_to_pennylane
 
 FROM_TANGELO = {
     "qiskit": translate_op_to_qiskit,
     "cirq": translate_op_to_cirq,
-    "qulacs": translate_op_to_qulacs
+    "qulacs": translate_op_to_qulacs,
+    "pennylane": translate_op_to_pennylane
 }
 
 TO_TANGELO = {
     "qiskit": translate_op_from_qiskit,
     "cirq": translate_op_from_cirq,
-    "qulacs": translate_op_from_qulacs
+    "qulacs": translate_op_from_qulacs,
+    "pennylane": translate_op_from_pennylane
 }
 
 

--- a/tangelo/linq/translator/translate_qulacs.py
+++ b/tangelo/linq/translator/translate_qulacs.py
@@ -219,7 +219,4 @@ def translate_op_from_qulacs(qubit_operator):
 
         tangelo_op += QubitOperator(pauli_term, qubit_operator.get_term(term_i).get_coef())
 
-    # Clean the QubitOperator.
-    tangelo_op.compress()
-
     return tangelo_op

--- a/tangelo/linq/translator/translate_qulacs.py
+++ b/tangelo/linq/translator/translate_qulacs.py
@@ -22,8 +22,6 @@ necessary to account for:
     may also differ.
 """
 
-import warnings
-
 from numpy import exp, cos, sin
 
 from tangelo.toolboxes.operators import QubitOperator

--- a/tangelo/linq/translator/translate_qulacs.py
+++ b/tangelo/linq/translator/translate_qulacs.py
@@ -181,13 +181,12 @@ def translate_c_to_qulacs(source_circuit, noise_model=None, save_measurements=Fa
     return target_circuit
 
 
-def translate_op_to_qulacs(qubit_operator, n_qubits=None):
+def translate_op_to_qulacs(qubit_operator):
     """Helper function to translate a Tangelo QubitOperator to a qulacs general
     quantum operator.
 
     Args:
         qubit_operator (tangelo.toolboxes.operators.QubitOperator): Self-explanatory.
-        n_qubits (int): Number of qubits, ignored.
 
     Returns:
         (qulacs_core.GeneralQuantumOperator): Qulacs quantum operator.

--- a/tangelo/linq/translator/translate_qulacs.py
+++ b/tangelo/linq/translator/translate_qulacs.py
@@ -22,6 +22,8 @@ necessary to account for:
     may also differ.
 """
 
+import warnings
+
 from numpy import exp, cos, sin
 
 from tangelo.toolboxes.operators import QubitOperator
@@ -179,12 +181,13 @@ def translate_c_to_qulacs(source_circuit, noise_model=None, save_measurements=Fa
     return target_circuit
 
 
-def translate_op_to_qulacs(qubit_operator):
+def translate_op_to_qulacs(qubit_operator, n_qubits=None):
     """Helper function to translate a Tangelo QubitOperator to a qulacs general
     quantum operator.
 
     Args:
         qubit_operator (tangelo.toolboxes.operators.QubitOperator): Self-explanatory.
+        n_qubits (int): Number of qubits, ignored.
 
     Returns:
         (qulacs_core.GeneralQuantumOperator): Qulacs quantum operator.

--- a/tangelo/linq/translator/translate_qulacs.py
+++ b/tangelo/linq/translator/translate_qulacs.py
@@ -207,7 +207,8 @@ def translate_op_from_qulacs(qubit_operator):
 
     tangelo_op = QubitOperator()
 
-    # Not considering 0: "I", because it is not a valid action in openfermion.
+    # Not considering 0: "I", because it is not a valid action in
+    # openfermion-like qubit operators.
     qulacs_pauli_id_to_string = {1: "X", 2: "Y", 3: "Z"}
 
     n_terms = qubit_operator.get_term_count()

--- a/tangelo/linq/translator/translate_qulacs.py
+++ b/tangelo/linq/translator/translate_qulacs.py
@@ -195,8 +195,8 @@ def translate_op_to_qulacs(qubit_operator):
 
 
 def translate_op_from_qulacs(qubit_operator):
-    """Helper function to translate qulacs general quantum operator to a Tangelo
-    QubitOperator.
+    """Helper function to translate a qulacs general quantum operator to a
+    Tangelo QubitOperator.
 
     Args:
         qubit_operator (qulacs_core.GeneralQuantumOperator): Self-explanatory.


### PR DESCRIPTION
Highlights:
- Added 2-way translation of qubit operator in several open-source packages (cirq, qulacs, pennylane, projectq). The translation in qulacs can now be handled by the proper function (issue https://github.com/qulacs/qulacs/issues/303 resolved);
- Added testsfor the translation from and to tangelo qubit operators;
- Used the `translate_operator` in the `target_cirq.py` and `target_qulacs.py` simulator files;
- Added docs to `QulacsSimulator.expectation_value_from_prepared_state` method.
- Moved the qubit operator cleaning into the main `translate_operator` function.

EDIT: @JamesB-1qbit asked me a question about the time execution for the qulacs translation. Apparently, the qulacs function was way slower (maybe due to the memory leak). Here are the times for 100 random 50-qubit operators -> 0.09 +- 0.05s (qulacs) vs 0.05 +- 0.03s (custom code with a loop). I think it is better to use external code, as we won't have the task of maintaining it.

