### PR TITLE
Fixed identity operator evaluation and extended the accepted input types in compute_rdms

### DIFF
--- a/tangelo/linq/helpers/circuits/measurement_basis.py
+++ b/tangelo/linq/helpers/circuits/measurement_basis.py
@@ -58,7 +58,7 @@ def pauli_string_to_of(pauli_string):
     """ Converts a string of I,X,Y,Z Pauli operators to an Openfermion-style
     representation.
     """
-    return [(i, p) for i, p in enumerate(pauli_string) if p != 'I']
+    return tuple([(i, p) for i, p in enumerate(pauli_string) if p != 'I'])
 
 
 def pauli_of_to_string(pauli_op, n_qubits):

--- a/tangelo/toolboxes/molecular_computation/rdms.py
+++ b/tangelo/toolboxes/molecular_computation/rdms.py
@@ -82,14 +82,15 @@ def compute_rdms(ferm_ham, mapping, up_then_down, exp_vals=None, exp_data=None, 
 
     # Initialize exp_vals
     if isinstance(exp_vals, dict) and set(map(type, exp_vals)) == {str}:
-        exp_vals = {tuple(pauli_string_to_of(term)): exp_val for term, exp_val in exp_vals.items()}
-    elif exp_vals is None:
+        exp_vals = {pauli_string_to_of(term): exp_val for term, exp_val in exp_vals.items()}
+
+    if isinstance(exp_data, dict) and set(map(type, exp_data)) == {str}:
+        exp_data = {pauli_string_to_of(term): data for term, data in exp_data.items()}
+
+    if exp_vals is None:
         exp_vals = dict()
 
     n_qubits = get_qubit_number(mapping, ferm_ham.n_spinorbitals)
-
-    if isinstance(exp_data, dict) and set(map(type, exp_data)) == {tuple}:
-        exp_vals = {pauli_of_to_string(term, n_qubits): data for term, data in exp_data.items()}
 
     # Go over all terms in fermionic Hamiltonian
     for term in ferm_ham.terms:
@@ -114,23 +115,30 @@ def compute_rdms(ferm_ham, mapping, up_then_down, exp_vals=None, exp_data=None, 
 
         if isinstance(shadow, ClassicalShadow):
             eigenvalue = shadow.get_observable(qubit_term, **eval_args)
-
         else:
             for qterm, coeff in qubit_term.terms.items():
                 if coeff.real != 0:
 
+                    # qterm = (), i.e. tensor product of I.
                     if not qterm:
                         exp_val = 1.
+                    # Already computed expectation value of qterm.
                     elif qterm in exp_vals:
                         exp_val = exp_vals[qterm]
+                    # Case where there is at least one missing entry in exp_vals
+                    # (in this case, exp_data is None and we cannot compute the
+                    # eigenvalue).
+                    elif exp_data is None:
+                        raise RuntimeError(f"Missing {qterm} entry in exp_vals.")
+                    # Expectation value that can be computed from exp_data.
                     else:
                         ps = pauli_of_to_string(qterm, n_qubits)
-                        bases = get_compatible_bases(ps, list(exp_data.keys()))
+                        bases = get_compatible_bases(ps, [pauli_of_to_string(term, n_qubits) for term in exp_data.keys()])
 
                         if not bases:
-                            raise RuntimeError(f"No experimental data for basis {ps}")
+                            raise RuntimeError(f"No experimental data for basis {qterm}.")
 
-                        hist = aggregate_histograms(*[Histogram(exp_data[basis]) for basis in bases])
+                        hist = aggregate_histograms(*[Histogram(exp_data[pauli_string_to_of(basis)]) for basis in bases])
                         exp_val = hist.get_expectation_value(qterm, 1.)
                         exp_vals[qterm] = exp_val
 

--- a/tangelo/toolboxes/molecular_computation/rdms.py
+++ b/tangelo/toolboxes/molecular_computation/rdms.py
@@ -19,12 +19,11 @@ import itertools as it
 import numpy as np
 
 from tangelo.toolboxes.molecular_computation.coefficients import spatial_from_spinorb
-from tangelo.linq.helpers import pauli_string_to_of, get_compatible_bases
+from tangelo.linq.helpers import pauli_string_to_of, pauli_of_to_string, get_compatible_bases
 from tangelo.toolboxes.operators import FermionOperator
 from tangelo.toolboxes.measurements import ClassicalShadow
 from tangelo.toolboxes.post_processing import Histogram, aggregate_histograms
 from tangelo.toolboxes.qubit_mappings.mapping_transform import fermion_to_qubit_mapping, get_qubit_number
-from tangelo.linq.helpers.circuits import pauli_of_to_string
 
 
 def matricize_2rdm(two_rdm, n_orbitals):
@@ -81,9 +80,14 @@ def compute_rdms(ferm_ham, mapping, up_then_down, exp_vals=None, exp_data=None, 
     if [exp_vals, exp_data, shadow].count(None) != 2:
         raise RuntimeError("Arguments exp_vals, exp_data and shadow are mutually exclusive. Provide exactly one of them.")
 
+    if isinstance(exp_data, dict) and set(map(type, exp_data)) == {tuple}:
+        exp_vals = {pauli_of_to_string(term): data for term, data in exp_data.items()}
+
     # Initialize exp_vals
-    exp_vals = {pauli_string_to_of(term): exp_val for term, exp_val in exp_data.items()} \
-        if isinstance(exp_vals, dict) else {}
+    if isinstance(exp_vals, dict) and set(map(type, exp_vals)) == {str}:
+        exp_vals = {pauli_string_to_of(term): exp_val for term, exp_val in exp_vals.items()}
+    elif exp_vals is None:
+        exp_vals = dict()
 
     n_qubits = get_qubit_number(mapping, ferm_ham.n_spinorbitals)
 
@@ -115,8 +119,10 @@ def compute_rdms(ferm_ham, mapping, up_then_down, exp_vals=None, exp_data=None, 
             for qterm, coeff in qubit_term.terms.items():
                 if coeff.real != 0:
 
-                    if qterm in exp_vals:
-                        exp_val = exp_vals[qterm] if qterm else 1.
+                    if not qterm:
+                        exp_val = 1.
+                    elif qterm in exp_vals:
+                        exp_val = exp_vals[qterm]
                     else:
                         ps = pauli_of_to_string(qterm, n_qubits)
                         bases = get_compatible_bases(ps, list(exp_data.keys()))

--- a/tangelo/toolboxes/molecular_computation/rdms.py
+++ b/tangelo/toolboxes/molecular_computation/rdms.py
@@ -80,16 +80,16 @@ def compute_rdms(ferm_ham, mapping, up_then_down, exp_vals=None, exp_data=None, 
     if [exp_vals, exp_data, shadow].count(None) != 2:
         raise RuntimeError("Arguments exp_vals, exp_data and shadow are mutually exclusive. Provide exactly one of them.")
 
-    if isinstance(exp_data, dict) and set(map(type, exp_data)) == {tuple}:
-        exp_vals = {pauli_of_to_string(term): data for term, data in exp_data.items()}
-
     # Initialize exp_vals
     if isinstance(exp_vals, dict) and set(map(type, exp_vals)) == {str}:
-        exp_vals = {pauli_string_to_of(term): exp_val for term, exp_val in exp_vals.items()}
+        exp_vals = {tuple(pauli_string_to_of(term)): exp_val for term, exp_val in exp_vals.items()}
     elif exp_vals is None:
         exp_vals = dict()
 
     n_qubits = get_qubit_number(mapping, ferm_ham.n_spinorbitals)
+
+    if isinstance(exp_data, dict) and set(map(type, exp_data)) == {tuple}:
+        exp_vals = {pauli_of_to_string(term, n_qubits): data for term, data in exp_data.items()}
 
     # Go over all terms in fermionic Hamiltonian
     for term in ferm_ham.terms:

--- a/tangelo/toolboxes/molecular_computation/tests/test_rdms.py
+++ b/tangelo/toolboxes/molecular_computation/tests/test_rdms.py
@@ -37,7 +37,7 @@ ferm_op.n_electrons = 2
 ferm_op.spin = 0
 
 exp_data_strings = json.load(open(pwd_this_test + "/data/H2_raw_exact.dat", "r"))
-exp_data_tuples = {pauli_string_to_of(k): v for k,v in exp_data_strings.items()}
+exp_data_tuples = {pauli_string_to_of(k): v for k, v in exp_data_strings.items()}
 
 temp_hist_tuples = {k: Histogram(freqs, 10000) for k, freqs in exp_data_tuples.items()}
 temp_hist_tuples[((0, "Z"),)] = aggregate_histograms(temp_hist_tuples[((0, "Z"), (1, "Z"))], temp_hist_tuples[((0, "Z"), (1, "X"))])
@@ -46,7 +46,7 @@ temp_hist_tuples[((0, "X"),)] = aggregate_histograms(temp_hist_tuples[((0, "X"),
 temp_hist_tuples[((1, "X"),)] = aggregate_histograms(temp_hist_tuples[((0, "Z"), (1, "X"))], temp_hist_tuples[((0, "X"), (1, "X"))])
 
 exp_values_tuples = {term: hist.get_expectation_value(term) for term, hist in temp_hist_tuples.items()}
-exp_values_strings = {pauli_of_to_string(k, 2): v for k,v in exp_values_tuples.items()}
+exp_values_strings = {pauli_of_to_string(k, 2): v for k, v in exp_values_tuples.items()}
 
 rdm1ssr = np.array([[1.97454854+0.j, 0.+0.j],
                  [0.+0.j, 0.02545146+0.j]])


### PR DESCRIPTION
There were several bugs preventing users to use the compute rdms function:
1.
 ```python
 {pauli_string_to_of(term): exp_val for term, exp_val in exp_data.items()}
``` 
to
```python
{pauli_string_to_of(term): exp_val for term, exp_val in exp_vals.items()}
``` 
(wrong dictionary).

2.
List are unhashable, changed output type of the `pauli_string_to_of` function to a tuple.

3. 
```python
if qterm in exp_vals:
    exp_val = exp_vals[qterm] if qterm else 1.
```
was failing for the `()` term. I added a conditional statement.

4. Can now accept dictionaries with string ("IXYZ") or openfermion-like ((1, "X), (2, "Y"), ...) terms.
