### PR TITLE
Disabling OS-DMET

### DIFF
--- a/tangelo/problem_decomposition/dmet/dmet_problem_decomposition.py
+++ b/tangelo/problem_decomposition/dmet/dmet_problem_decomposition.py
@@ -339,15 +339,11 @@ class DMETProblemDecomposition(ProblemDecomposition):
 
             # Construct guess orbitals for fragment SCF calculations.
             # Carry out SCF calculation for a fragment.
-            guess_orbitals, nelec_high_ab = helpers._fragment_guess_rohf_uhf(
-                t_list, bath_orb, chemical_potential, norb_high, nelec_high,
-                self.orbitals.active_fock_alpha, self.orbitals.active_fock_beta,
-                self.orbitals.number_active_electrons_alpha,
-                self.orbitals.number_active_electrons_beta)
-
-            mf_fragment, fock_frag_copy, mol_frag = helpers._fragment_scf_rohf_uhf(
-                nelec_high_ab, two_ele, fock, nelec_high, norb_high,
-                guess_orbitals, chemical_potential, False)
+            guess_orbitals = helpers._fragment_guess_rhf(t_list, bath_orb, chemical_potential, norb_high, nelec_high,
+                                                            self.orbitals.active_fock)
+            mf_fragment, fock_frag_copy, mol_frag = helpers._fragment_scf_rhf(
+                t_list, two_ele, fock, nelec_high, norb_high, guess_orbitals,
+                chemical_potential)
 
             scf_fragments.append([mf_fragment, fock_frag_copy, mol_frag, t_list, one_ele, two_ele, fock])
 

--- a/tangelo/problem_decomposition/dmet/dmet_problem_decomposition.py
+++ b/tangelo/problem_decomposition/dmet/dmet_problem_decomposition.py
@@ -99,7 +99,8 @@ class DMETProblemDecomposition(ProblemDecomposition):
         if not self.molecule:
             raise ValueError(f"A SecondQuantizedMolecule object must be provided when instantiating DMETProblemDecomposition.")
 
-        self.uhf = self.molecule.uhf
+        if self.molecule.uhf or self.molecule.spin != 0:
+            raise NotImplementedError("ROHF-DMET and UHF-DMET have been disabled temporarily for code validation purposes.")
 
         # Converting our interface to pyscf.mol.gto and pyscf.scf (used by this
         # code).
@@ -137,7 +138,7 @@ class DMETProblemDecomposition(ProblemDecomposition):
 
             # Force recomputing the mean field if the atom ordering has been changed.
             warnings.warn("The mean field will be recomputed even if one has been provided by the user.", RuntimeWarning)
-            self.mean_field = scf.UHF(self.molecule) if self.uhf else scf.RHF(self.molecule)
+            self.mean_field = scf.RHF(self.molecule)
             self.mean_field.verbose = 0
             self.mean_field.scf()
 
@@ -227,19 +228,13 @@ class DMETProblemDecomposition(ProblemDecomposition):
             raise TypeError(f"Invalid electron localization function. Expecting a function.")
 
         # Construct orbital object.
-        self.orbitals = helpers._orbitals(self.molecule, self.mean_field, range(self.molecule.nao_nr()), self.electron_localization, self.uhf)
+        self.orbitals = helpers._orbitals(self.molecule, self.mean_field, range(self.molecule.nao_nr()), self.electron_localization, False)
 
         # TODO: remove last argument, combining fragments not supported.
         self.orb_list, self.orb_list2, _ = helpers._fragment_constructor(self.molecule, self.fragment_atoms, 0)
 
         # Calculate the 1-RDM for the entire molecule.
-        if self.molecule.spin == 0 and not self.uhf:
-            self.onerdm_low = helpers._low_rdm_rhf(self.orbitals.active_fock, self.orbitals.number_active_electrons)
-        else:
-            self.onerdm_low = helpers._low_rdm_rohf_uhf(self.orbitals.active_fock_alpha,
-                                                        self.orbitals.active_fock_beta,
-                                                        self.orbitals.number_active_electrons_alpha,
-                                                        self.orbitals.number_active_electrons_beta)
+        self.onerdm_low = helpers._low_rdm_rhf(self.orbitals.active_fock, self.orbitals.number_active_electrons)
 
     def simulate(self):
         """Perform DMET loop to optimize the chemical potential. It converges
@@ -344,22 +339,15 @@ class DMETProblemDecomposition(ProblemDecomposition):
 
             # Construct guess orbitals for fragment SCF calculations.
             # Carry out SCF calculation for a fragment.
-            if self.uhf or self.molecule.spin != 0:
-                guess_orbitals, nelec_high_ab = helpers._fragment_guess_rohf_uhf(
-                    t_list, bath_orb, chemical_potential, norb_high, nelec_high,
-                    self.orbitals.active_fock_alpha, self.orbitals.active_fock_beta,
-                    self.orbitals.number_active_electrons_alpha,
-                    self.orbitals.number_active_electrons_beta)
+            guess_orbitals, nelec_high_ab = helpers._fragment_guess_rohf_uhf(
+                t_list, bath_orb, chemical_potential, norb_high, nelec_high,
+                self.orbitals.active_fock_alpha, self.orbitals.active_fock_beta,
+                self.orbitals.number_active_electrons_alpha,
+                self.orbitals.number_active_electrons_beta)
 
-                mf_fragment, fock_frag_copy, mol_frag = helpers._fragment_scf_rohf_uhf(
-                    nelec_high_ab, two_ele, fock, nelec_high, norb_high,
-                    guess_orbitals, chemical_potential, self.uhf)
-            else:
-                guess_orbitals = helpers._fragment_guess_rhf(t_list, bath_orb, chemical_potential, norb_high, nelec_high,
-                                                             self.orbitals.active_fock)
-                mf_fragment, fock_frag_copy, mol_frag = helpers._fragment_scf_rhf(
-                    t_list, two_ele, fock, nelec_high, norb_high, guess_orbitals,
-                    chemical_potential)
+            mf_fragment, fock_frag_copy, mol_frag = helpers._fragment_scf_rohf_uhf(
+                nelec_high_ab, two_ele, fock, nelec_high, norb_high,
+                guess_orbitals, chemical_potential, False)
 
             scf_fragments.append([mf_fragment, fock_frag_copy, mol_frag, t_list, one_ele, two_ele, fock])
 
@@ -435,7 +423,7 @@ class DMETProblemDecomposition(ProblemDecomposition):
             # We create a dummy SecondQuantizedMolecule with a DMETFragment class.
             # It has the same important attributes and methods to be used with
             # functions of this package.
-            dummy_mol = SecondQuantizedDMETFragment(mol_frag, mf_fragment, fock, fock_frag_copy, t_list, one_ele, two_ele, self.uhf)
+            dummy_mol = SecondQuantizedDMETFragment(mol_frag, mf_fragment, fock, fock_frag_copy, t_list, one_ele, two_ele, False)
 
             if self.verbose:
                 print("\t\tFragment Number : # ", i + 1)
@@ -473,11 +461,9 @@ class DMETProblemDecomposition(ProblemDecomposition):
                     solver_fragment.build()
                     solver_fragment.simulate()
 
-                if purify and solver_fragment.molecule.n_active_electrons == 2 and not self.uhf:
+                if purify and solver_fragment.molecule.n_active_electrons == 2:
                     onerdm, twordm = solver_fragment.get_rdm(solver_fragment.optimal_var_params, resample=resample, sum_spin=False)
                     onerdm, twordm = mcweeny_purify_2rdm(twordm)
-                elif self.uhf:
-                    onerdm, twordm = solver_fragment.get_rdm_uhf(solver_fragment.optimal_var_params, resample=resample)
                 else:
                     onerdm, twordm = solver_fragment.get_rdm(solver_fragment.optimal_var_params, resample=resample)
                 if save_results:
@@ -485,14 +471,9 @@ class DMETProblemDecomposition(ProblemDecomposition):
                     self.rdm_measurements[i] = self.solver_fragment_dict[i].rdm_freq_dict
 
             # Compute the fragment energy and sum up the number of electrons
-            if self.uhf:
-                fragment_energy, _, one_rdm_alpha, one_rdm_beta = self._compute_energy_unrestricted(
-                    mf_fragment, onerdm, twordm, fock_frag_copy, t_list, one_ele, two_ele, fock)
-                n_electron_frag = np.trace(one_rdm_alpha[ : t_list[0], : t_list[0]]) + np.trace(one_rdm_beta[ : t_list[0], : t_list[0]])
-            else:
-                fragment_energy, _, one_rdm = self._compute_energy_restricted(mf_fragment, onerdm, twordm,
-                    fock_frag_copy, t_list, one_ele, two_ele, fock)
-                n_electron_frag = np.trace(one_rdm[: t_list[0], : t_list[0]])
+            fragment_energy, _, one_rdm = self._compute_energy_restricted(mf_fragment, onerdm, twordm,
+                fock_frag_copy, t_list, one_ele, two_ele, fock)
+            n_electron_frag = np.trace(one_rdm[: t_list[0], : t_list[0]])
 
             number_of_electron += n_electron_frag
 
@@ -529,7 +510,7 @@ class DMETProblemDecomposition(ProblemDecomposition):
             # Unpacking the information for the selected fragment.
             mf_fragment, fock_frag_copy, mol_frag, t_list, one_ele, two_ele, fock = info_fragment
 
-            dummy_mol = SecondQuantizedDMETFragment(mol_frag, mf_fragment, fock, fock_frag_copy, t_list, one_ele, two_ele, self.uhf)
+            dummy_mol = SecondQuantizedDMETFragment(mol_frag, mf_fragment, fock, fock_frag_copy, t_list, one_ele, two_ele, False)
 
             # Buiding SCF fragments and quantum circuit. Resources are then
             # estimated. For classical sovlers, this functionality is not

--- a/tangelo/problem_decomposition/tests/dmet/test_osdmet.py
+++ b/tangelo/problem_decomposition/tests/dmet/test_osdmet.py
@@ -27,6 +27,7 @@ LiO2 = """
 
 class OSDMETProblemDecompositionTest(unittest.TestCase):
 
+    @unittest.skip("Open-shell DMET has been disabled.")
     def test_lio2_sto6g_rohf(self):
         """Tests the result from OS-DMET (ROHF) against a value from a reference
         implementation with nao localization and CCSD solution to fragments.
@@ -47,6 +48,7 @@ class OSDMETProblemDecompositionTest(unittest.TestCase):
 
         self.assertAlmostEqual(energy, -156.6317605935, places=4)
 
+    @unittest.skip("Open-shell DMET has been disabled.")
     def test_lio2_sto6g_uhf(self):
         """Tests the result from OS-DMET (UHF) against a value from a reference
         implementation with nao localization and CCSD solution to fragments.


### PR DESCRIPTION
OS-DMET is giving good results for the test system that was available (LiO2). However, some tests with very simple systems resulted in energies with very significant errors (>1 Hartree). 

|                             System                            | DMET / Hartree | Mean-field / Hartree | CCSD / Hartree |
|:-------------------------------------------------------------:|:--------------:|:--------------------:|:--------------:|
| 7 H atoms, separation of 1.0 ang, minao, UHF                  | -2.8673        | -3.5606              | -3.6288        |
| 7 H atoms, separation of 1.0 ang, minao, ROHF                 | -2.5086        | -3.5527              | -3.6284        |
| 9 H atoms, separation of 1.0 ang, minao, UHF or ROHF          | No conv.       | -                    | -              |
| 10 H atoms (spin=2), separation of 1.0 ang minao, ROHF or UHF | Tol. issue     | -                    | -              |
| 10 H atoms (spin=0), separation of 1.0 ang minao, UHF         | -5.3675        | -5.2641              | -5.3779        |

Because of this fact, we will temporarily disabled the open-shell DMET feature during the investigation.