### PR TITLE
Bugfix: expectation of imaginary qubit_op with desired meas result

### DIFF
--- a/tangelo/linq/target/backend.py
+++ b/tangelo/linq/target/backend.py
@@ -314,8 +314,10 @@ class Backend(abc.ABC):
                 qb_op_real.terms[term], qb_op_imag.terms[term] = coef.real, coef.imag
             qb_op_real.compress()
             qb_op_imag.compress()
-            exp_real = self.get_expectation_value(qb_op_real, state_prep_circuit, initial_statevector=initial_statevector)
-            exp_imag = self.get_expectation_value(qb_op_imag, state_prep_circuit, initial_statevector=initial_statevector)
+            exp_real = self.get_expectation_value(qb_op_real, state_prep_circuit, initial_statevector=initial_statevector,
+                                                  desired_meas_result=desired_meas_result)
+            exp_imag = self.get_expectation_value(qb_op_imag, state_prep_circuit, initial_statevector=initial_statevector,
+                                                  desired_meas_result=desired_meas_result)
             return exp_real if (exp_imag == 0.) else exp_real + 1.0j * exp_imag
 
     def get_variance(self, qubit_operator, state_prep_circuit, initial_statevector=None, desired_meas_result=None):

--- a/tangelo/linq/tests/test_simulator.py
+++ b/tangelo/linq/tests/test_simulator.py
@@ -420,7 +420,7 @@ class TestSimulateStatevector(unittest.TestCase):
 
     def test_get_exp_value_mixed_state_desired_measurement_with_shots(self):
         """ Get expectation value of mixed state by post-selecting on desired measurement."""
-        qubit_operator = QubitOperator("X0 X1") + QubitOperator("Y0 Y1") + QubitOperator("Z0 Z1")
+        qubit_operator = QubitOperator("X0 X1") + QubitOperator("Y0 Y1") + QubitOperator("Z0 Z1") + QubitOperator("X0 Y1", 1j)
 
         ham = get_sparse_operator(qubit_operator).toarray()
         exact_sv = np.array([0.+0.j, 0.+0.j, 0.87758256+0.j, -0.47942554+0.j])


### PR DESCRIPTION
I found an error in the `get_expectation_value` with a `desired_meas_result` and non-real `QubitOperator`