### PR TITLE
Depth function performance increase

### DIFF
--- a/tangelo/linq/circuit.py
+++ b/tangelo/linq/circuit.py
@@ -195,7 +195,7 @@ class Circuit:
 
     def depth(self):
         """ Return the depth of the quantum circuit, by computing the number of moments. Does not count
-        qubit initialization as a moment (unlike Cirq, for example). Computes from scratch.
+        qubit initialization as a moment (unlike Cirq, for example). Compute from scratch.
         """
         # List of qubit indices involved in each moment. Look up dict for latest moment for each index.
         moments = list()
@@ -224,15 +224,6 @@ class Circuit:
                 else:
                     moments.append(qubits)
         return len(moments)
-
-        # Option 2: No moment info. Thats the whole thing. 2x speedup on h20_321g example
-        # latest_moment = dict()
-        # for g in self:
-        #     qubits = set(g.target) if g.control is None else set(g.target + g.control)
-        #     b = max([latest_moment.get(i, -1) for i in qubits])
-        #     for i in qubits:
-        #         latest_moment[i] = b + 1
-        # return max(latest_moment.values()) + 1
 
     def trim_qubits(self):
         """Trim unnecessary qubits and update indices with the lowest values possible.


### PR DESCRIPTION
Just a look up dictionary really. No increase in memory, we apparently go faster than cirq itself to compute depth from scratch on circuits of depth 100K+ and 150K gates. Things are instant.
