### PR TITLE
Combinatorial mapping of fermionic Hamiltonians

### DIFF
--- a/tangelo/toolboxes/qubit_mappings/__init__.py
+++ b/tangelo/toolboxes/qubit_mappings/__init__.py
@@ -16,3 +16,4 @@ from .jordan_wigner import jordan_wigner
 from .bravyi_kitaev import bravyi_kitaev
 from .symmetry_conserving_bravyi_kitaev import symmetry_conserving_bravyi_kitaev
 from .jkmn import jkmn
+from .combinatorial import combinatorial

--- a/tangelo/toolboxes/qubit_mappings/combinatorial.py
+++ b/tangelo/toolboxes/qubit_mappings/combinatorial.py
@@ -116,6 +116,9 @@ def element_to_qubitop(n_qubits, i, j, coeff=1.):
         i (int): i row of the matrix element.
         j (int): j column of the matrix element.
         coeff (complex): Value at position i,j in the matrix.
+
+    Returns:
+        QubitOperator: Self-explanatory.
     """
 
     # Must add 2 to the padding because of the "0b" prefix.

--- a/tangelo/toolboxes/qubit_mappings/combinatorial.py
+++ b/tangelo/toolboxes/qubit_mappings/combinatorial.py
@@ -1,0 +1,222 @@
+# Copyright 2021 Good Chemistry Company.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Combinatorial mapping as described in references (1) and (2). Instead of the
+occupation (or other quantity), the Fock configurations are the elements of the
+basis set. In consequence, the number of required qubits scales with the number
+of electronic configuration instead of the number of spinorbitals.
+
+References:
+    1. Streltsov, A. I., Alon, O. E. & Cederbaum, L. S. General mapping for
+        bosonic and fermionic operators in Fock space. Phys. Rev. A 81, 022124
+        (2010).
+    2. Chamaki, D., Metcalf, M. & de Jong, W. A. Compact Molecular Simulation on
+        Quantum Computers via Combinatorial Mapping and Variational State
+        Preparation. Preprint at https://doi.org/10.48550/arXiv.2205.11742
+        (2022).
+"""
+
+import itertools
+from collections import OrderedDict
+from math import ceil
+from copy import deepcopy
+
+import numpy as np
+from scipy.special import comb
+from openfermion.linalg import qubit_operator_sparse
+from openfermion.transforms import chemist_ordered
+
+from tangelo.linq.helpers.circuits.measurement_basis import pauli_string_to_of
+from tangelo.toolboxes.operators import QubitOperator
+
+
+def combinatorial(ferm_op, n_modes, n_electrons):
+    """Function to transform the fermionic Hamiltonian into a basis constructed
+    in the Fock space.
+
+    Args:
+        ferm_op (FermionOperator). Fermionic operator, with alternate ordering
+            as followed in the openfermion package
+        n_modes: Number of relevant molecular orbitals, i.e. active molecular
+            orbitals.
+        n_electrons: Number of active electrons.
+
+    Returns:
+        QubitOperator: Self-explanatory.
+    """
+
+    # The chemist ordering seperates some 1-body and 2-body terms.
+    ferm_op_chemist = chemist_ordered(ferm_op)
+
+    # Specify the number of alpha and beta electrons.
+    if isinstance(n_electrons, tuple) and len(n_electrons) == 2:
+        n_alpha, n_beta = n_electrons
+    elif isinstance(n_electrons, int) and n_electrons % 2 == 0:
+        n_alpha = n_beta = n_electrons // 2
+    else:
+        raise ValueError(f"{n_electrons} is not a valid entry for n_electrons, must be a tuple or an int.")
+
+    # Get the number of qubits n.
+    n_choose_alpha = comb(n_modes, n_alpha, exact=True)
+    n = ceil(np.log2(n_choose_alpha * comb(n_modes, n_beta, exact=True)))
+
+    # Construct the basis set where each configutation is mapped to a unique
+    # integer.
+    basis_set_alpha = basis(n_modes, n_alpha)
+    basis_set_beta = basis(n_modes, n_beta)
+    basis_set = OrderedDict()
+    for sigma_alpha, int_alpha in basis_set_alpha.items():
+        for sigma_beta, int_beta in basis_set_beta.items():
+            # Alternate ordering (like FermionOperator in openfermion).
+            sigma = tuple(sorted([2*sa for sa in sigma_alpha] + [2*sb+1 for sb in sigma_beta]))
+            unique_int = (int_alpha * n_choose_alpha) + int_beta
+            basis_set[sigma] = unique_int
+
+    # H_1 and H_2 initialization to 2^n * 2^n matrices.
+    h_one = np.zeros((2**n, 2**n), dtype=complex)
+    h_two = np.zeros((2**n, 2**n), dtype=complex)
+
+    # Check what is the effect of every term.
+    for term, coeff in ferm_op_chemist.terms.items():
+        # Core term
+        if not term:
+            continue
+
+        for b, unique_int in basis_set.items():
+            if len(term) == 2:
+                new_state, phase = one_body_op_on_state(term, b)
+
+                if new_state:
+                    new_unique_int = basis_set[new_state]
+                    h_one[unique_int][new_unique_int] += phase * coeff
+
+            elif len(term) == 4:
+                new_state, phase = two_body_op_on_state(term, b)
+
+                if new_state:
+                    new_unique_int = basis_set[new_state]
+                    h_two[unique_int][new_unique_int] += phase * coeff
+
+    # Return the compact Hamiltonian H_c.
+    h_c = h_one + h_two
+
+    return h_to_qubitop(h_c, n)
+
+
+def f(sigma, M):
+    """TODO
+
+    Args:
+
+    Returns:
+
+    """
+    N = len(sigma)
+
+    terms_k = [comb(M - sigma[N - 1 - k] - 1, k + 1) for k in range(N)]
+    unique_int = comb(M, N) - 1 - np.sum(terms_k)
+
+    if not unique_int.is_integer():
+        raise ValueError
+
+    return int(unique_int)
+
+
+def basis(M, N):
+    """TODO
+
+    Args:
+
+    Returns:
+
+    """
+    mapping = [(sigma, f(sigma, M)) for sigma in itertools.combinations(range(M), N)]
+    return OrderedDict(mapping)
+
+
+def one_body_op_on_state(op, state_in):
+    """"""
+
+    assert len(op) == 2, f"{op}"
+
+    state = deepcopy(state_in)
+    state = list(state)
+
+    creation_op, anhilation_op = op
+
+    # Confirm dagger order to the left.
+    assert creation_op[1] == 1
+    assert anhilation_op[1] == 0
+
+    creation_qubit, _ = creation_op
+    anhilation_qubit, _ = anhilation_op
+
+    if anhilation_qubit in state:
+        state.remove(anhilation_qubit)
+    else:
+        return 0, 0.
+
+    if creation_qubit not in state:
+        state = [*state, creation_qubit]
+    else:
+        return 0, 0.
+
+    if anhilation_qubit > creation_qubit:
+        d = sum(creation_qubit < i < anhilation_qubit for i in state)
+    elif anhilation_qubit < creation_qubit:
+        d = sum(anhilation_qubit < i < creation_qubit for i in state)
+    else:
+        d = 0
+
+    return tuple(sorted(state)), (-1)**d
+
+
+def two_body_op_on_state(ops, state_in):
+    """
+    """
+
+    op_kq = (ops[-2], ops[-1])
+    state_kq, phase_kq = one_body_op_on_state(op_kq, state_in)
+
+    if not state_kq:
+        return state_kq, phase_kq
+
+    op_sl = (ops[0], ops[1])
+    state, phase_sl = one_body_op_on_state(op_sl, state_kq)
+
+    return state, phase_kq * phase_sl
+
+
+# TODO: change the algorithm to not need the full matrix.
+def h_to_qubitop(h_c, n):
+    """TODO
+
+    Args:
+
+    Returns:
+
+    """
+    qu_op = QubitOperator()
+
+    for pauli_tensor in itertools.product("IXYZ", repeat=n):
+        pauli_word = "".join(pauli_tensor)
+        term = pauli_string_to_of(pauli_word)
+
+        term_op = QubitOperator(term, 1.)
+
+        c_j = np.trace(h_c.conj().T @ qubit_operator_sparse(term_op, n_qubits=n).todense())
+        qu_op += QubitOperator(term, c_j)
+
+    qu_op /= np.sqrt(4**n)
+    return qu_op

--- a/tangelo/toolboxes/qubit_mappings/combinatorial.py
+++ b/tangelo/toolboxes/qubit_mappings/combinatorial.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Good Chemistry Company.
+# Copyright 2023 Good Chemistry Company.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Combinatorial mapping as described in references (1) and (2). Instead of the
-occupation (or other quantity), the Fock configurations are the elements of the
-basis set. In consequence, the number of required qubits scales with the number
-of electronic configuration instead of the number of spinorbitals.
+"""Combinatorial mapping as described in references (1) and (2). In contrast to
+qubit mappings such as JW, BK that use occupation/parity, the mappings in this
+file use the Fock configurations as the elements of the basis set. Thus, the
+number of required qubits scales with the number of electronic configuration
+instead of the number of spinorbitals.
 
 References:
     1. Streltsov, A. I., Alon, O. E. & Cederbaum, L. S. General mapping for
@@ -48,9 +49,9 @@ def combinatorial(ferm_op, n_modes, n_electrons):
     Args:
         ferm_op (FermionOperator). Fermionic operator, with alternate ordering
             as followed in the openfermion package
-        n_modes: Number of relevant molecular orbitals, i.e. active molecular
+        n_modes (int): Number of relevant molecular orbitals, i.e. active molecular
             orbitals.
-        n_electrons: Number of active electrons.
+        n_electrons (int): Number of active electrons.
 
     Returns:
         QubitOperator: Self-explanatory.
@@ -123,11 +124,11 @@ def basis(M, N):
             configuration to unique integers.
     """
 
-    mapping = [(sigma, f(sigma, M)) for sigma in itertools.combinations(range(M), N)]
+    mapping = [(sigma, conf_to_integer(sigma, M)) for sigma in itertools.combinations(range(M), N)]
     return OrderedDict(mapping)
 
 
-def f(sigma, M):
+def conf_to_integer(sigma, M):
     """Function to map an electronic configuration to a unique integer, as done
     in arXiv.2205.11742 eq. (14).
 
@@ -161,7 +162,7 @@ def one_body_op_on_state(op, state_in):
             spinorbital indices where there is an electron.
 
     Returns:
-        tuple or 0: Resulting state with the same form as in the input state.
+        tuple: Resulting state with the same form as in the input state.
             Can be 0.
         int: Phase shift. Can be -1 or 1.
     """
@@ -185,13 +186,13 @@ def one_body_op_on_state(op, state_in):
     if anhilation_qubit in state:
         state.remove(anhilation_qubit)
     else:
-        return 0, 0
+        return (), 0
 
     # Creation logics on the state.
     if creation_qubit not in state:
         state = [*state, creation_qubit]
     else:
-        return 0, 0
+        return (), 0
 
     # Compute the phase shift.
     if anhilation_qubit > creation_qubit:

--- a/tangelo/toolboxes/qubit_mappings/combinatorial.py
+++ b/tangelo/toolboxes/qubit_mappings/combinatorial.py
@@ -126,11 +126,11 @@ def element_to_qubitop(n_qubits, i, j, coeff=1.):
 
     qu_op = QubitOperator("", coeff)
     for qubit, (bi, bj) in enumerate(zip(bin_i[2:][::-1], bin_j[2:][::-1])):
-        if (bi, bj) ==  ("0", "0"):
+        if (bi, bj) == ("0", "0"):
             qu_op *= 0.5 + QubitOperator(f"Z{qubit}", 0.5)
-        elif (bi, bj) ==  ("0", "1"):
+        elif (bi, bj) == ("0", "1"):
             qu_op *= QubitOperator(f"X{qubit}", 0.5) + QubitOperator(f"Y{qubit}", 0.5j)
-        elif (bi, bj) ==  ("1", "0"):
+        elif (bi, bj) == ("1", "0"):
             qu_op *= QubitOperator(f"X{qubit}", 0.5) + QubitOperator(f"Y{qubit}", -0.5j)
         # The remaining case is 11.
         else:

--- a/tangelo/toolboxes/qubit_mappings/combinatorial.py
+++ b/tangelo/toolboxes/qubit_mappings/combinatorial.py
@@ -70,8 +70,7 @@ def combinatorial(ferm_op, n_modes, n_electrons):
     n_choose_alpha = comb(n_modes, n_alpha, exact=True)
     n = ceil(np.log2(n_choose_alpha * comb(n_modes, n_beta, exact=True)))
 
-    # Construct the basis set where each configutation is mapped to a unique
-    # integer.
+    # Construct the basis set where each configutation is mapped to a unique integer.
     basis_set_alpha = basis(n_modes, n_alpha)
     basis_set_beta = basis(n_modes, n_beta)
     basis_set = OrderedDict()
@@ -112,7 +111,7 @@ def element_to_qubitop(n_qubits, i, j, coeff=1.):
     """Map a matrix element to a qubit operator.
 
     Args:
-        n_qubits (int): Self-explanatory.
+        n_qubits (int): The number of qubits that the whole matrix represents.
         i (int): i row of the matrix element.
         j (int): j column of the matrix element.
         coeff (complex): Value at position i,j in the matrix.
@@ -127,11 +126,11 @@ def element_to_qubitop(n_qubits, i, j, coeff=1.):
 
     qu_op = QubitOperator("", coeff)
     for qubit, (bi, bj) in enumerate(zip(bin_i[2:][::-1], bin_j[2:][::-1])):
-        if bi == "0" and bj == "0":
+        if (bi, bj) ==  ("0", "0"):
             qu_op *= 0.5 + QubitOperator(f"Z{qubit}", 0.5)
-        elif bi == "0" and bj == "1":
+        elif (bi, bj) ==  ("0", "1"):
             qu_op *= QubitOperator(f"X{qubit}", 0.5) + QubitOperator(f"Y{qubit}", 0.5j)
-        elif bi == "1" and bj == "0":
+        elif (bi, bj) ==  ("1", "0"):
             qu_op *= QubitOperator(f"X{qubit}", 0.5) + QubitOperator(f"Y{qubit}", -0.5j)
         # The remaining case is 11.
         else:
@@ -186,7 +185,7 @@ def one_body_op_on_state(op, state_in):
 
     Args:
         op (tuple): Operator, written as ((qubit_i, 1), (qubit_j, 0)), where 0/1
-            means anhilation/creation on the specified qubit.
+            means annihilation/creation on the specified qubit.
         state_in (tuple): Electronic configuration described as tuple of
             spinorbital indices where there is an electron.
 
@@ -196,24 +195,24 @@ def one_body_op_on_state(op, state_in):
         int: Phase shift. Can be -1 or 1.
     """
 
-    assert len(op) == 2, f"Operator {op} has length {len(op)}, a length of 2 is expected."
+    assert len(op) == 2, f"Operator {op} has length {len(op)}, but a length of 2 is expected."
 
     # Copy the state, then transform it into a list (it will be mutated).
     state = deepcopy(state_in)
     state = list(state)
 
-    # Unpack the creation and anhilation operators.
-    creation_op, anhilation_op = op
+    # Unpack the creation and annihilation operators.
+    creation_op, annihilation_op = op
     creation_qubit, creation_dagger = creation_op
-    anhilation_qubit, anhilation_dagger = anhilation_op
+    annihilation_qubit, annihilation_dagger = annihilation_op
 
     # Confirm dagger operator to the left.
-    assert creation_dagger == 1
-    assert anhilation_dagger == 0
+    assert creation_dagger == 1, f"The left operator in {op} is not a creation operator."
+    assert annihilation_dagger == 0, f"The right operator in {op} is not an annihilation operator."
 
-    # Anhilation logics on the state.
-    if anhilation_qubit in state:
-        state.remove(anhilation_qubit)
+    # annihilation logics on the state.
+    if annihilation_qubit in state:
+        state.remove(annihilation_qubit)
     else:
         return (), 0
 
@@ -224,10 +223,10 @@ def one_body_op_on_state(op, state_in):
         return (), 0
 
     # Compute the phase shift.
-    if anhilation_qubit > creation_qubit:
-        d = sum(creation_qubit < i < anhilation_qubit for i in state)
-    elif anhilation_qubit < creation_qubit:
-        d = sum(anhilation_qubit < i < creation_qubit for i in state)
+    if annihilation_qubit > creation_qubit:
+        d = sum(creation_qubit < i < annihilation_qubit for i in state)
+    elif annihilation_qubit < creation_qubit:
+        d = sum(annihilation_qubit < i < creation_qubit for i in state)
     else:
         d = 0
 

--- a/tangelo/toolboxes/qubit_mappings/tests/test_combinatorial.py
+++ b/tangelo/toolboxes/qubit_mappings/tests/test_combinatorial.py
@@ -1,0 +1,41 @@
+# Copyright 2023 Good Chemistry Company.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from tangelo.molecule_library import mol_H2_sto3g
+from tangelo.toolboxes.operators import QubitOperator
+from tangelo.toolboxes.qubit_mappings import combinatorial
+
+
+class CombinatorialTest(unittest.TestCase):
+
+    def test_combinatorial_h2_sto3g(self):
+        """Test the mapping of H2 STO-3G to a combinatorial (qubit) Hamiltonian."""
+
+        H_ferm = mol_H2_sto3g.fermionic_hamiltonian
+        qubit_op = combinatorial(H_ferm, mol_H2_sto3g.n_active_mos,
+            mol_H2_sto3g.n_active_electrons)
+
+        ref_qubit_op = QubitOperator("", -0.3399536)
+        ref_qubit_op += QubitOperator("Y0 Y1", -0.181288)
+        ref_qubit_op += QubitOperator("Z0", -0.3939836)
+        ref_qubit_op += QubitOperator("Z0 Z1", 0.0112365)
+        ref_qubit_op += QubitOperator("Z1", -0.3939836)
+
+        self.assertTrue(qubit_op.isclose(ref_qubit_op, tol=1e-4))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tangelo/toolboxes/qubit_mappings/tests/test_combinatorial.py
+++ b/tangelo/toolboxes/qubit_mappings/tests/test_combinatorial.py
@@ -14,9 +14,88 @@
 
 import unittest
 
+import numpy as np
+
 from tangelo.molecule_library import mol_H2_sto3g
 from tangelo.toolboxes.operators import QubitOperator
 from tangelo.toolboxes.qubit_mappings import combinatorial
+from tangelo.toolboxes.qubit_mappings.combinatorial import element_to_qubitop, basis, \
+    conf_to_integer, one_body_op_on_state
+
+
+class FunctionsCombinatorialTest(unittest.TestCase):
+
+    def test_element_to_qubitop_2by2(self):
+        """Test the mapping of a 2x2 matrix to qubit operators."""
+
+        array = np.array([
+            [1, 2.22],
+            [3j, 4+1j]
+        ])
+
+        quop_00 = element_to_qubitop(1, 0, 0, array[0][0])
+        quop_01 = element_to_qubitop(1, 0, 1, array[0][1])
+        quop_10 = element_to_qubitop(1, 1, 0, array[1][0])
+        quop_11 = element_to_qubitop(1, 1, 1, array[1][1])
+
+        self.assertEqual(quop_00, QubitOperator("", 0.5) + QubitOperator("Z0", 0.5))
+        self.assertEqual(quop_01, QubitOperator("X0", 0.5*2.22) + QubitOperator("Y0", 0.5j*2.22))
+        self.assertEqual(quop_10, QubitOperator("X0", 0.5*3j) + QubitOperator("Y0", -0.5j*3j))
+        self.assertEqual(quop_11, QubitOperator("", 0.5*(4+1j)) + QubitOperator("Z0", -0.5*(4+1j)))
+
+    def test_element_to_qubitop_4by4(self):
+        """Test the mapping of a 4x4 matrix element to a qubit operator."""
+
+        quop_01_00 = element_to_qubitop(2, 1, 0, 5.)
+
+        ref_op = QubitOperator("X0", 0.25) + QubitOperator("Y0", -0.25j) + \
+            QubitOperator("X0 Z1", 0.25) + QubitOperator("Y0 Z1", -0.25j)
+        ref_op *= 5.
+
+        self.assertEqual(quop_01_00, ref_op)
+
+    def test_basis(self):
+        """Test the basis function to construct a combinatorial set."""
+
+        bs = basis(4, 1)
+
+        self.assertEqual(bs.keys(), {(0,), (1,), (2,), (3,)})
+        self.assertEqual(list(bs.values()), [0, 1, 2, 3])
+
+    def test_conf_to_integer(self):
+        """Test the mapping of an electronic configuration to a unique int."""
+
+        self.assertEqual(conf_to_integer((0, 1), 4), 0)
+        self.assertEqual(conf_to_integer((0, 2), 4), 1)
+        self.assertEqual(conf_to_integer((0, 3), 4), 2)
+        self.assertEqual(conf_to_integer((1, 2), 4), 3)
+        self.assertEqual(conf_to_integer((1, 3), 4), 4)
+        self.assertEqual(conf_to_integer((2, 3), 4), 5)
+
+    def test_one_body_op_on_state(self):
+        """Test the function that applies an operator a^{\dagger}_j a_i."""
+
+        conf_in = (0, 1, 2)
+
+        # Test case where i is in conf_in and not j (phase unchanged).
+        conf_out_a, phase_a = one_body_op_on_state(((3, 1), (0, 0)), conf_in)
+        self.assertEqual(conf_out_a, (1, 2, 3))
+        self.assertEqual(phase_a, 1)
+
+        # Test case where i is in conf_in and not j (phase changed).
+        conf_out_b, phase_b = one_body_op_on_state(((3, 1), (1, 0)), conf_in)
+        self.assertEqual(conf_out_b, (0, 2, 3))
+        self.assertEqual(phase_b, -1)
+
+        # Test case where i is not in conf_in.
+        conf_out_c, phase_c = one_body_op_on_state(((4, 1), (3, 0)), conf_in)
+        self.assertEqual(conf_out_c, ())
+        self.assertEqual(phase_c, 0)
+
+        # Test case where j is in conf_in.
+        conf_out_d, phase_d = one_body_op_on_state(((2, 1), (1, 0)), conf_in)
+        self.assertEqual(conf_out_d, ())
+        self.assertEqual(phase_d, 0)
 
 
 class CombinatorialTest(unittest.TestCase):


### PR DESCRIPTION
Combinatorial mapping, as described in:
- Streltsov, A. I., Alon, O. E. & Cederbaum, L. S. General mapping for bosonic and fermionic operators in Fock space. Phys. Rev. A 81, 022124 (2010).
- Chamaki, D., Metcalf, M. & de Jong, W. A. Compact Molecular Simulation on Quantum Computers via Combinatorial Mapping and Variational State Preparation. Preprint at https://doi.org/10.48550/arXiv.2205.11742 (2022).

TODOs:
- ~~Remove the use of `h_to_qubitop` to be more efficient. There is maybe a way to add qubit operator terms on the fly during the construction of the `h_c` matrix (and thus removed the need to keep `h_c`).~~
- ~~Add tests.~~

Edit:
~~Tests are failing at the moment because of a bug in pennylane, see https://github.com/PennyLaneAI/pennylane/issues/3867.~~