### PR TITLE
deterministic desired_meas_result

### DIFF
--- a/tangelo/linq/__init__.py
+++ b/tangelo/linq/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from .gate import *
-from .circuit import Circuit, stack, remove_small_rotations, remove_redundant_gates
+from .circuit import Circuit, stack, remove_small_rotations, remove_redundant_gates, get_unitary_circuit_pieces
 from .translator import *
 from .simulator import get_backend
 from .target.backend import get_expectation_value_from_frequencies_oneterm

--- a/tangelo/linq/circuit.py
+++ b/tangelo/linq/circuit.py
@@ -19,7 +19,7 @@ characteristics (width, size ...).
 """
 
 import copy
-from typing import List, Tuple
+from typing import List, Tuple, Iterator
 
 import numpy as np
 from cirq.contrib.svg import SVGCircuit
@@ -55,6 +55,7 @@ class Circuit:
         self._gate_counts = dict()
         self._n_qubit_gate_counts = dict()
         self._variational_gates = []
+        self._probabilities = dict()
 
         if gates:
             _ = [self.add_gate(g) for g in gates]
@@ -144,6 +145,14 @@ class Circuit:
         if any MEASURE gate was explicitly added by the user.
         """
         return "MEASURE" in self.counts
+
+    @property
+    def success_probabilities(self):
+        """Returns the dictionary of probabilities populated by simulating with a desired_meas_result."""
+        if not self.is_mixed_state:
+            return {"": 1}
+        else:
+            return self._probabilities
 
     def draw(self):
         """Method to output a prettier version of the circuit for use in jupyter notebooks that uses cirq SVGCircuit"""
@@ -445,27 +454,26 @@ def remove_redundant_gates(circuit):
 
 
 def get_unitary_circuit_pieces(circuit: Circuit) -> Tuple[List[Circuit], List[int]]:
-    """Split circuit into the unitary circuits between non-unitary MEASURE gates.
+    """Split circuit into the unitary circuits between mid-circuit non-unitary MEASURE gates.
 
     Args:
         circuit (Circuit): the circuit to split
 
     Returns:
-        List[Circuit]: The set of unitary circuits with a terminal non-unitary operation.
+        List[Circuit]: The list of unitary circuits with a terminal non-unitary operation.
         List[int]: The qubits that the "MEASURE" operation is applied to.
     """
 
     n_qubits = circuit.width
-    circuit_list = list()
-    measure_qubits = list()
-    gate_list = list()
-    for g in circuit._gates:
-        if g.name != "MEASURE":
-            gate_list += [Gate(g.name, g.target, g.control, g.parameter, g.is_variational)]
-        else:
-            circuit_list += [Circuit(gate_list.copy(), n_qubits=n_qubits)]
-            measure_qubits += [g.target[0]]
-            gate_list = list()
-    circuit_list += [Circuit(gate_list.copy(), n_qubits=n_qubits)]
+    circuits, gates, measure_qubits = list(), list(), list()
 
-    return circuit_list, measure_qubits
+    for g in circuit:
+        if g.name != "MEASURE":
+            gates += [Gate(g.name, g.target, g.control, g.parameter, g.is_variational)]
+        else:
+            circuits += [Circuit(gates.copy(), n_qubits=n_qubits)]
+            measure_qubits += [g.target[0]]
+            gates = list()
+    circuits += [Circuit(gates.copy(), n_qubits=n_qubits)]
+
+    return circuits, measure_qubits

--- a/tangelo/linq/circuit.py
+++ b/tangelo/linq/circuit.py
@@ -148,7 +148,14 @@ class Circuit:
 
     @property
     def success_probabilities(self):
-        """Returns the dictionary of probabilities populated by simulating with a desired_meas_result."""
+        """Returns the dictionary of probabilities populated by simulating with different desired_meas_result.
+
+        The keys of the dictionary are bit strings, corresponding to the desired outcomes in the order
+        the measurement gates arise in the circuit.
+
+        Each bit string must be simulated using a backend with n_shots=None and desired_meas_result=bitstring
+        in order to populate the corresponding probability.
+        """
         if not self.is_mixed_state:
             return {"": 1}
         else:
@@ -471,9 +478,9 @@ def get_unitary_circuit_pieces(circuit: Circuit) -> Tuple[List[Circuit], List[in
         if g.name != "MEASURE":
             gates += [Gate(g.name, g.target, g.control, g.parameter, g.is_variational)]
         else:
-            circuits += [Circuit(gates.copy(), n_qubits=n_qubits)]
+            circuits += [Circuit(copy.deepcopy(gates), n_qubits=n_qubits)]
             measure_qubits += [g.target[0]]
             gates = list()
-    circuits += [Circuit(gates.copy(), n_qubits=n_qubits)]
+    circuits += [Circuit(copy.deepcopy(gates), n_qubits=n_qubits)]
 
     return circuits, measure_qubits

--- a/tangelo/linq/target/backend.py
+++ b/tangelo/linq/target/backend.py
@@ -133,7 +133,7 @@ def collapse_statevector_to_desired_measurement(statevector, qubit, result, orde
         raise ValueError(f"Statevector length of {statevector_length} is not a power of 2.")
 
     if qubit > n_qubits-1:
-        raise ValueError("qubit to measure is larger than number of qubits in statevector")
+        raise ValueError("qubit index to measure is larger than number of qubits in statevector")
 
     if result not in {0, 1}:
         raise ValueError(f"Result is not valid, must be an integer of 0 or 1 but received {result}")

--- a/tangelo/linq/target/backend.py
+++ b/tangelo/linq/target/backend.py
@@ -117,29 +117,25 @@ def collapse_statevector_to_desired_measurement(statevector, qubit, result, orde
 
     Args:
         statevector (array): The statevector for which the collapse to the desired qubit value is performed.
-        qubit (int): Index if target qubit to collapse in the desired classical state.
+        qubit (int): Index of target qubit to collapse in the desired classical state.
         result (int): 0 or 1.
         order (string): The qubit ordering of the statevector, lsq_first or msq_first.
 
     Returns:
-        array: the collapsed and renormalized statevector
-        float: the probability this occured
+        array: The collapsed and renormalized statevector.
+        float: The probability for the desired measurement to occur.
     """
 
-    statevector_length = len(statevector)
-    n_qubits = round(math.log2(statevector_length))
+    n_qubits = round(math.log2(len(statevector)))
 
-    if 2**n_qubits != statevector_length:
-        raise ValueError(f"Statevector length of {statevector_length} is not a power of 2.")
+    if 2**n_qubits != len(statevector):
+        raise ValueError(f"Statevector length of {len(statevector)} is not a power of 2.")
 
     if qubit > n_qubits-1:
         raise ValueError("qubit index to measure is larger than number of qubits in statevector")
 
     if result not in {0, 1}:
         raise ValueError(f"Result is not valid, must be an integer of 0 or 1 but received {result}")
-
-    if len(statevector) != 2**n_qubits:
-        raise ValueError("Statevector length is not 2**n_qubits")
 
     if order.lower() not in {"lsq_first", "msq_first"}:
         raise ValueError("Order must be lsq_first or msq_first")
@@ -154,7 +150,7 @@ def collapse_statevector_to_desired_measurement(statevector, qubit, result, orde
     sqrt_probability = np.linalg.norm(sv_selected)
 
     if sqrt_probability < 1.e-14:
-        raise ValueError("Probability of desired measurement result is zero.")
+        raise ValueError(f"Probability of desired measurement={0} for qubit={qubit} is zero.")
     sv_selected = sv_selected/sqrt_probability  # casting issue if inplace for probability 1
 
     return sv_selected, sqrt_probability**2
@@ -699,23 +695,20 @@ class Backend(abc.ABC):
 
         return state_binstr if use_ordering and (self.statevector_order == "lsq_first") else state_binstr[::-1]
 
-    def collapse_statevector_to_desired_measurement(self, statevector, qubit, result, order=None):
+    def collapse_statevector_to_desired_measurement(self, statevector, qubit, result):
         """Take 0 or 1 part of a statevector for a given qubit and return a normalized statevector and probability.
 
         Args:
             statevector (array): The statevector for which the collapse to the desired qubit value is performed.
             qubit (int): The index of the qubit to collapse to the classical result.
             result (string): "0" or "1".
-            order (str): If not set, ordering of the backend is used.
 
         Returns:
             array: the collapsed and renormalized statevector
             float: the probability this occured
         """
-        if order is None:
-            order = self.backend_info()['statevector_order']
 
-        return collapse_statevector_to_desired_measurement(statevector, qubit, result, order)
+        return collapse_statevector_to_desired_measurement(statevector, qubit, result, self.backend_info()['statevector_order'])
 
     @staticmethod
     @abc.abstractmethod

--- a/tangelo/linq/target/backend.py
+++ b/tangelo/linq/target/backend.py
@@ -155,7 +155,7 @@ def collapse_statevector_to_desired_measurement(statevector, qubit, result, orde
 
     if sqrt_probability < 1.e-14:
         raise ValueError("Probability of desired measurement result is zero.")
-    sv_selected /= sqrt_probability
+    sv_selected = sv_selected/sqrt_probability  # casting issue if inplace for probability 1
 
     return sv_selected, sqrt_probability**2
 

--- a/tangelo/linq/target/backend.py
+++ b/tangelo/linq/target/backend.py
@@ -148,9 +148,9 @@ def collapse_statevector_to_desired_measurement(statevector, qubit, result, orde
     sv_selected = sv_selected.flatten()
 
     sqrt_probability = np.linalg.norm(sv_selected)
-
     if sqrt_probability < 1.e-14:
         raise ValueError(f"Probability of desired measurement={0} for qubit={qubit} is zero.")
+
     sv_selected = sv_selected/sqrt_probability  # casting issue if inplace for probability 1
 
     return sv_selected, sqrt_probability**2

--- a/tangelo/linq/target/target_qiskit.py
+++ b/tangelo/linq/target/target_qiskit.py
@@ -150,6 +150,8 @@ class QiskitSimulator(Backend):
             frequencies = self.all_frequencies
 
         # desired_meas_result without a noise model
+        # Split circuit into chunks between mid-circuit measurements. Simulate a chunk, collapse the statevector according
+        # to the desired measurement and simulate the next chunk using this new statevector as input
         elif desired_meas_result is not None:
             backend, translated_circuit = aer_backend_with_statevector(translated_circuit)
 

--- a/tangelo/linq/target/target_qiskit.py
+++ b/tangelo/linq/target/target_qiskit.py
@@ -17,7 +17,7 @@ from collections import Counter
 
 import numpy as np
 
-from tangelo.linq import Circuit
+from tangelo.linq import Circuit, get_unitary_circuit_pieces
 from tangelo.linq.target.backend import Backend
 from tangelo.linq.translator import translate_circuit as translate_c
 from tangelo.linq.noisy_simulation.noise_models import get_qiskit_noise_model
@@ -76,6 +76,16 @@ class QiskitSimulator(Backend):
         n_meas = source_circuit.counts.get("MEASURE", 0)
         qiskit_noise_model = get_qiskit_noise_model(self._noise_model) if self._noise_model else None
 
+        def load_statevector_to_translated_circuit(translated_circuit, initial_statevector):
+            "Load statevector into translated_circuit"
+            n_qubits = int(math.log2(len(initial_statevector)))
+            n_meas = source_circuit.counts.get("MEASURE", 0)
+            n_registers = n_meas + source_circuit.width if save_mid_circuit_meas else source_circuit.width
+            initial_state_circuit = self.qiskit.QuantumCircuit(n_qubits, n_registers)
+            initial_state_circuit.initialize(initial_statevector, list(range(n_qubits)))
+            translated_circuit = initial_state_circuit.compose(translated_circuit)
+            return translated_circuit
+
         def run_and_measure_one_shot(backend, translated_circuit):
             "Return statevector and mid-circuit measurement for one shot"
             sim_results = backend.run(translated_circuit, noise_model=qiskit_noise_model, shots=1).result()
@@ -83,19 +93,18 @@ class QiskitSimulator(Backend):
             measure = next(iter(self.qiskit.result.marginal_counts(sim_results, indices=list(range(n_meas))).get_counts()))[::-1]
             return current_state, measure
 
-        translated_circuit = translate_c(source_circuit, "qiskit", output_options={"save_measurements": save_mid_circuit_meas})
+        if desired_meas_result is not None and not self._noise_model:
+            unitary_circuits, qubits = get_unitary_circuit_pieces(source_circuit)
+            translated_circuit = translate_c(unitary_circuits[0], "qiskit", output_options={"save_measurements": False})
+        else:
+            translated_circuit = translate_c(source_circuit, "qiskit", output_options={"save_measurements": save_mid_circuit_meas})
 
         # If requested, set initial state
         if initial_statevector is not None:
             if self._noise_model:
                 raise ValueError("Cannot load an initial state if using a noise model, with Qiskit")
             else:
-                n_qubits = int(math.log2(len(initial_statevector)))
-                n_meas = source_circuit.counts.get("MEASURE", 0)
-                n_registers = n_meas + source_circuit.width if save_mid_circuit_meas else source_circuit.width
-                initial_state_circuit = self.qiskit.QuantumCircuit(n_qubits, n_registers)
-                initial_state_circuit.initialize(initial_statevector, list(range(n_qubits)))
-                translated_circuit = initial_state_circuit.compose(translated_circuit)
+                translated_circuit = load_statevector_to_translated_circuit(translated_circuit, initial_statevector)
 
         # Noiseless simulation using the statevector simulator
         if not self._noise_model and not source_circuit.is_mixed_state:
@@ -142,28 +151,28 @@ class QiskitSimulator(Backend):
         elif desired_meas_result is not None:
             backend, translated_circuit = aer_backend_with_statevector(translated_circuit)
 
-            samples = dict()
-            self._current_state = None
-            n_attempts = 0
+            self.success_probability = 1
 
-            # Permit 0.1% probability events
-            max_attempts = 1000
+            for i in range(len(unitary_circuits[:-1])):
+                sim_results = backend.run(translated_circuit).result()
+                current_state = sim_results.get_statevector(translated_circuit)
+                sv, cprob = self.collapse_statevector_to_desired_measurement(np.asarray(current_state), qubits[i],
+                                                                             int(desired_meas_result[i]), source_circuit.width)
+                self.success_probability *= cprob
 
-            while self._current_state is None and n_attempts < max_attempts:
-                current_state, measure = run_and_measure_one_shot(backend, translated_circuit)
+                translated_circuit = translate_c(unitary_circuits[i+1], "qiskit", output_options={"save_measurements": False})
+                translated_circuit = load_statevector_to_translated_circuit(translated_circuit, sv)
+                backend, translated_circuit = aer_backend_with_statevector(translated_circuit)
 
-                if measure == desired_meas_result:
-                    self._current_state = current_state
-                    if self.n_shots is not None:
-                        self.all_frequencies = {measure + state[::-1]: count for state, count in current_state.sample_counts(self.n_shots).items()}
-                    else:
-                        freqs = self._statevector_to_frequencies(np.array(current_state))
-                        self.all_frequencies = {measure + meas: val for meas, val in freqs.items()}
+            sim_results = backend.run(translated_circuit).result()
+            current_state = sim_results.get_statevector(translated_circuit)
+            self._current_state = np.asarray(current_state)
 
-                n_attempts += 1
-
-            if n_attempts == max_attempts:
-                raise ValueError(f"desired_meas_result was not measured after {n_attempts} attempts")
+            if self.n_shots is not None:
+                self.all_frequencies = {desired_meas_result + state[::-1]: count for state, count in current_state.sample_counts(self.n_shots).items()}
+            else:
+                freqs = self._statevector_to_frequencies(np.array(current_state))
+                self.all_frequencies = {desired_meas_result + meas: val for meas, val in freqs.items()}
 
             frequencies = self.all_frequencies.copy()
 

--- a/tangelo/linq/target/target_qiskit.py
+++ b/tangelo/linq/target/target_qiskit.py
@@ -97,16 +97,15 @@ class QiskitSimulator(Backend):
             # Split circuit into chunks between mid-circuit measurements. Simulate a chunk, collapse the statevector according
             # to the desired measurement and simulate the next chunk using this new statevector as input
             unitary_circuits, qubits = get_unitary_circuit_pieces(source_circuit)
-            translated_circuit = translate_c(unitary_circuits[0], "qiskit", output_options={"save_measurements": False})
         else:
             translated_circuit = translate_c(source_circuit, "qiskit", output_options={"save_measurements": save_mid_circuit_meas})
 
-        # If requested, set initial state
-        if initial_statevector is not None:
-            if self._noise_model:
-                raise ValueError("Cannot load an initial state if using a noise model, with Qiskit")
-            else:
-                translated_circuit = load_statevector(translated_circuit, initial_statevector)
+            # If requested, set initial state
+            if initial_statevector is not None:
+                if self._noise_model:
+                    raise ValueError("Cannot load an initial state if using a noise model, with Qiskit")
+                else:
+                    translated_circuit = load_statevector(translated_circuit, initial_statevector)
 
         # Noiseless simulation using the statevector simulator
         if not self._noise_model and not source_circuit.is_mixed_state:
@@ -153,24 +152,37 @@ class QiskitSimulator(Backend):
         # Split circuit into chunks between mid-circuit measurements. Simulate a chunk, collapse the statevector according
         # to the desired measurement and simulate the next chunk using this new statevector as input
         elif desired_meas_result is not None:
-            backend, translated_circuit = aer_backend_with_statevector(translated_circuit)
 
             success_probability = 1
 
-            for i in range(len(unitary_circuits[:-1])):
-                sim_results = backend.run(translated_circuit).result()
-                current_state = sim_results.get_statevector(translated_circuit)
-                sv, cprob = self.collapse_statevector_to_desired_measurement(np.asarray(current_state), qubits[i],
-                                                                             int(desired_meas_result[i]))
+            if initial_statevector is not None:
+                sv = np.asarray(initial_statevector, dtype=complex)
+            else:
+                sv = np.zeros(2**source_circuit.width)
+                sv[0] = 1.
+
+            for i, circ in enumerate(unitary_circuits[:-1]):
+                if circ.size != 0:
+                    translated_circuit = translate_c(circ, "qiskit", output_options={"save_measurements": False})
+                    translated_circuit = load_statevector(translated_circuit, sv)
+                    backend, translated_circuit = aer_backend_with_statevector(translated_circuit)
+                    sim_results = backend.run(translated_circuit).result()
+                    current_state = sim_results.get_statevector(translated_circuit)
+                    sv, cprob = self.collapse_statevector_to_desired_measurement(np.asarray(current_state), qubits[i],
+                                                                                 int(desired_meas_result[i]))
+                else:
+                    sv, cprob = self.collapse_statevector_to_desired_measurement(sv, qubits[i],
+                                                                                 int(desired_meas_result[i]))
+
                 success_probability *= cprob
 
-                translated_circuit = translate_c(unitary_circuits[i+1], "qiskit", output_options={"save_measurements": False})
-                translated_circuit = load_statevector(translated_circuit, sv)
-                backend, translated_circuit = aer_backend_with_statevector(translated_circuit)
-
+            translated_circuit = translate_c(unitary_circuits[-1], "qiskit", output_options={"save_measurements": False})
+            translated_circuit = load_statevector(translated_circuit, sv)
+            backend, translated_circuit = aer_backend_with_statevector(translated_circuit)
             sim_results = backend.run(translated_circuit).result()
             current_state = sim_results.get_statevector(translated_circuit)
             self._current_state = np.asarray(current_state)
+
             source_circuit._probabilities[desired_meas_result] = success_probability
 
             if self.n_shots is not None:

--- a/tangelo/linq/target/target_qulacs.py
+++ b/tangelo/linq/target/target_qulacs.py
@@ -103,8 +103,9 @@ class QulacsSimulator(Backend):
                 unitary_circuits, qubits = get_unitary_circuit_pieces(source_circuit)
 
                 for i, circ in enumerate(unitary_circuits[:-1]):
-                    translated_circuit = translate_c(circ, "qulacs", output_options={"save_measurements": True})
-                    translated_circuit.update_quantum_state(state)
+                    if circ.size > 0:
+                        translated_circuit = translate_c(circ, "qulacs", output_options={"save_measurements": True})
+                        translated_circuit.update_quantum_state(state)
                     sv, cprob = self.collapse_statevector_to_desired_measurement(state.get_vector(), qubits[i], int(desired_meas_result[i]))
                     success_probability *= cprob
                     state.load(sv)

--- a/tangelo/linq/tests/test_circuits.py
+++ b/tangelo/linq/tests/test_circuits.py
@@ -303,12 +303,18 @@ class TestCircuits(unittest.TestCase):
 
     def test_unitary_pieces(self):
         """ Test the splitting of circuit into unitary pieces between measurements."""
-        test_circuit = Circuit([Gate("X", 0), Gate("MEASURE", 1), Gate("CNOT", 0, 1), Gate("MEASURE", 0), Gate("MEASURE", 1)])
-        circuits = [Circuit([Gate("X", 0)], n_qubits=2),
-                    Circuit([Gate("CNOT", 0, 1)], n_qubits=2),
+        test_circuit = Circuit([Gate("H", 0), Gate("H", 1), Gate("MEASURE", 0),
+                                Gate("X", 1), Gate("MEASURE", 1),
+                                Gate("H", 0), Gate("H", 1), Gate("CNOT", control=0, target=1), Gate("MEASURE", 0),
+                                Gate("MEASURE", 1),
+                                Gate("H", 0), Gate("MEASURE", 1)])
+        circuits = [Circuit([Gate("H", 0), Gate("H", 1)], n_qubits=2),
+                    Circuit([Gate("X", 1)], n_qubits=2),
+                    Circuit([Gate("H", 0), Gate("H", 1), Gate("CNOT", control=0, target=1)], n_qubits=2),
                     Circuit(n_qubits=2),
+                    Circuit([Gate("H", 0)], n_qubits=2),
                     Circuit(n_qubits=2)]
-        measure_qs = [1, 0, 1]
+        measure_qs = [0, 1, 0, 1, 1]
         split_circuits, qubits_to_measure = get_unitary_circuit_pieces(test_circuit)
 
         for i, circ in enumerate(circuits[:-1]):

--- a/tangelo/linq/tests/test_circuits.py
+++ b/tangelo/linq/tests/test_circuits.py
@@ -22,7 +22,7 @@ import copy
 from math import pi
 from collections import Counter
 
-from tangelo.linq import Gate, Circuit, stack
+from tangelo.linq import Gate, Circuit, stack, get_unitary_circuit_pieces
 
 # Create several abstract circuits with different features
 mygates = [Gate("H", 2), Gate("CNOT", 1, control=0), Gate("CNOT", 2, control=1),
@@ -300,6 +300,21 @@ class TestCircuits(unittest.TestCase):
         self.assertEqual([g for g in circuit2], circuit2._gates)
         self.assertEqual([g for g in circuit3], circuit3._gates)
         self.assertEqual([g for g in circuit4], circuit4._gates)
+
+    def test_unitary_pieces(self):
+        """ Test the splitting of circuit into unitary pieces between measurements."""
+        test_circuit = Circuit([Gate("X", 0), Gate("MEASURE", 1), Gate("CNOT", 0, 1), Gate("MEASURE", 0), Gate("MEASURE", 1)])
+        circuits = [Circuit([Gate("X", 0)], n_qubits=2),
+                    Circuit([Gate("CNOT", 0, 1)], n_qubits=2),
+                    Circuit(n_qubits=2),
+                    Circuit(n_qubits=2)]
+        measure_qs = [1, 0, 1]
+        split_circuits, qubits_to_measure = get_unitary_circuit_pieces(test_circuit)
+
+        for i, circ in enumerate(circuits[:-1]):
+            self.assertEqual(circ, split_circuits[i])
+            self.assertEqual(measure_qs[i], qubits_to_measure[i])
+        self.assertEqual(circuits[-1], split_circuits[-1])
 
 
 if __name__ == "__main__":

--- a/tangelo/linq/tests/test_simulator.py
+++ b/tangelo/linq/tests/test_simulator.py
@@ -231,14 +231,15 @@ class TestSimulateStatevector(unittest.TestCase):
             f, sv = sim.simulate(circuit_mixed, desired_meas_result="0", return_statevector=True)
             np.testing.assert_array_almost_equal(sv, results[b])
             assert_freq_dict_almost_equal(f, freqs_exact, 1.e-7)
-            self.assertAlmostEqual(0.2919265817264289, sim.success_probability, places=7)
+            self.assertAlmostEqual(0.2919265817264289, circuit_mixed.success_probabilities["0"], places=7)
 
             # Test that initial_statevector is respected
-            f, sv = sim.simulate(Circuit([Gate("MEASURE", 0), Gate("MEASURE", 1)]), desired_meas_result="11",
+            meas_2_circuit = Circuit([Gate("MEASURE", 0), Gate("MEASURE", 1)])
+            f, sv = sim.simulate(meas_2_circuit, desired_meas_result="11",
                                  return_statevector=True, initial_statevector=initial_state)
             np.testing.assert_array_almost_equal(sv, initial_state)
             assert_freq_dict_almost_equal(f, {"11": 1}, 1.e-7)
-            self.assertAlmostEqual(1., sim.success_probability, places=7)
+            self.assertAlmostEqual(1., meas_2_circuit.success_probabilities["11"], places=7)
 
             # Test that ValueError is raised for desired_meas_result="0" with probability 0. i.e. loop exits successfully
             self.assertRaises(ValueError, sim.simulate, Circuit([Gate("X", 0), Gate("MEASURE", 0)]), True, None, "0")

--- a/tangelo/linq/tests/test_simulator.py
+++ b/tangelo/linq/tests/test_simulator.py
@@ -231,12 +231,14 @@ class TestSimulateStatevector(unittest.TestCase):
             f, sv = sim.simulate(circuit_mixed, desired_meas_result="0", return_statevector=True)
             np.testing.assert_array_almost_equal(sv, results[b])
             assert_freq_dict_almost_equal(f, freqs_exact, 1.e-7)
+            self.assertAlmostEqual(0.2919265817264289, sim.success_probability, places=7)
 
             # Test that initial_statevector is respected
             f, sv = sim.simulate(Circuit([Gate("MEASURE", 0), Gate("MEASURE", 1)]), desired_meas_result="11",
                                  return_statevector=True, initial_statevector=initial_state)
             np.testing.assert_array_almost_equal(sv, initial_state)
             assert_freq_dict_almost_equal(f, {"11": 1}, 1.e-7)
+            self.assertAlmostEqual(1., sim.success_probability, places=7)
 
             # Test that ValueError is raised for desired_meas_result="0" with probability 0. i.e. loop exits successfully
             self.assertRaises(ValueError, sim.simulate, Circuit([Gate("X", 0), Gate("MEASURE", 0)]), True, None, "0")


### PR DESCRIPTION
For a noiseless simulation with a desired_meas_result. This PR now implements

1. Circuit splitting between MEASURE operations to unitary_pieces
2. Simulate each unitary_piece and manually selected the desired_meas_result.

`sim.success_probability` is also saved.