### PR TITLE
Supporting symbols as parameters and add nsimplify to results

### DIFF
--- a/tangelo/linq/gate.py
+++ b/tangelo/linq/gate.py
@@ -20,6 +20,8 @@ from math import pi
 from typing import Union
 
 from numpy import integer, ndarray, floating
+from sympy import Symbol
+
 
 ONE_QUBIT_GATES = {"H", "X", "Y", "Z", "S", "T", "RX", "RY", "RZ", "PHASE"}
 TWO_QUBIT_GATES = {"CNOT", "CX", "CY", "CZ", "CRX", "CRY", "CRZ", "CPHASE", "XX", "SWAP"}
@@ -172,7 +174,7 @@ class Gate(dict):
 
         if self.parameter == "":
             new_parameter = ""
-        elif isinstance(self.parameter, (float, floating, int, integer)):
+        elif isinstance(self.parameter, (float, floating, int, integer, Symbol)):
             new_parameter = -self.parameter
         else:
             raise AttributeError(f"{self.name} is not an invertible gate when parameter is {self.parameter}")

--- a/tangelo/linq/target/target_sympy.py
+++ b/tangelo/linq/target/target_sympy.py
@@ -99,13 +99,14 @@ class SympySimulator(Backend):
             sympy.core.add.Add: Eigenvalue represented as a symbolic sum.
         """
 
-        from sympy import simplify, nsimplify
-        from sympy.physics.quantum import qapply, Dagger
+        from sympy import simplify, nsimplify, cos
+        from sympy.physics.quantum import Dagger
 
         prepared_state = self._current_state if prepared_state is None else prepared_state
         operator = translate_operator(qubit_operator, source="tangelo", target="sympy", n_qubits=n_qubits)
 
         eigenvalue = Dagger(prepared_state) * operator * prepared_state
+        eigenvalue = eigenvalue[0, 0].rewrite(cos)
         eigenvalue = simplify(eigenvalue)
         eigenvalue = nsimplify(eigenvalue, tolerance=1e-4, rational=True)
 

--- a/tangelo/linq/target/target_sympy.py
+++ b/tangelo/linq/target/target_sympy.py
@@ -48,7 +48,7 @@ class SympySimulator(Backend):
                 by the user (if not, set to None).
         """
 
-        from sympy import simplify, nsimplify
+        from sympy import simplify
         from sympy.physics.quantum import qapply
         from sympy.physics.quantum.qubit import Qubit, matrix_to_qubit, \
             qubit_to_matrix, measure_all
@@ -74,8 +74,7 @@ class SympySimulator(Backend):
 
         frequencies = dict()
         for vec, prob in measurements:
-            prob = simplify(prob, tolerance=1e-4)
-            prob = nsimplify(prob, tolerance=1e-4, rational=True)
+            prob = simplify(prob, tolerance=1e-4).evalf()
             if not prob.is_zero:
                 bistring = "".join(str(bit) for bit in reversed(vec.qubit_values))
                 frequencies[bistring] = prob
@@ -99,7 +98,7 @@ class SympySimulator(Backend):
             sympy.core.add.Add: Eigenvalue represented as a symbolic sum.
         """
 
-        from sympy import simplify, nsimplify, cos
+        from sympy import simplify, cos
         from sympy.physics.quantum import Dagger
 
         prepared_state = self._current_state if prepared_state is None else prepared_state
@@ -107,8 +106,7 @@ class SympySimulator(Backend):
 
         eigenvalue = Dagger(prepared_state) * operator * prepared_state
         eigenvalue = eigenvalue[0, 0].rewrite(cos)
-        eigenvalue = simplify(eigenvalue)
-        eigenvalue = nsimplify(eigenvalue, tolerance=1e-4, rational=True)
+        eigenvalue = simplify(eigenvalue).evalf()
 
         return eigenvalue
 

--- a/tangelo/linq/translator/translate_qubitop.py
+++ b/tangelo/linq/translator/translate_qubitop.py
@@ -76,7 +76,7 @@ def translate_operator(qubit_operator, source, target, n_qubits=None):
         if target in {"qiskit", "sympy"}:
             # The count_qubits function has no way to detect the number of
             # qubits when an operator is only a tensor product of I.
-            if qubit_operator == QubitOperator((), qubit_operator.constant):
+            if qubit_operator == QubitOperator((), qubit_operator.constant) and n_qubits is None:
                 raise ValueError("The number of qubits (n_qubits) must be provided.")
             n_qubits = count_qubits(qubit_operator) if n_qubits is None else n_qubits
             qubit_operator = FROM_TANGELO[target](qubit_operator, n_qubits)

--- a/tangelo/linq/translator/translate_sympy.py
+++ b/tangelo/linq/translator/translate_sympy.py
@@ -212,7 +212,7 @@ def translate_op_to_sympy(qubit_operator, n_qubits):
         sympy.core.add.Add: Summation of sympy.physics.quantum.TensorProduct
             objects.
     """
-    from sympy import Identity, Matrix, I, zeros
+    from sympy import Matrix, I, zeros
     from sympy.physics.quantum import TensorProduct
 
     # Pauli string to sympy Pauli algebra objects.

--- a/tangelo/linq/translator/translate_sympy.py
+++ b/tangelo/linq/translator/translate_sympy.py
@@ -212,15 +212,21 @@ def translate_op_to_sympy(qubit_operator, n_qubits):
         sympy.core.add.Add: Summation of sympy.physics.quantum.TensorProduct
             objects.
     """
-    from sympy import Identity
+    from sympy import Identity, Matrix, I, zeros
     from sympy.physics.paulialgebra import Pauli
     from sympy.physics.quantum import TensorProduct
 
     # Pauli string to sympy Pauli algebra objects.
-    map_to_paulis = {"I": Identity(1), "X": Pauli(1), "Y": Pauli(2), "Z": Pauli(3)}
+    #map_to_paulis = {"I": Identity(1), "X": Pauli(1), "Y": Pauli(2), "Z": Pauli(3)}
+    map_to_paulis = {
+        "I": Matrix([[1, 0], [0, 1]]),
+        "X": Matrix([[0, 1], [1, 0]]),
+        "Y": Matrix([[0, -I], [I, 0]]),
+        "Z": Matrix([[1, 0], [0, -1]])
+    }
 
     # Contruct the TensorProduct objects.
-    sum_tensor_paulis = 0.
+    sum_tensor_paulis = zeros(2**n_qubits, 2**n_qubits)
     for term_tuple, coeff in qubit_operator.terms.items():
         term_string = pauli_of_to_string(term_tuple, n_qubits)
         paulis = [map_to_paulis[p] for p in term_string[::-1]]

--- a/tangelo/linq/translator/translate_sympy.py
+++ b/tangelo/linq/translator/translate_sympy.py
@@ -213,11 +213,9 @@ def translate_op_to_sympy(qubit_operator, n_qubits):
             objects.
     """
     from sympy import Identity, Matrix, I, zeros
-    from sympy.physics.paulialgebra import Pauli
     from sympy.physics.quantum import TensorProduct
 
     # Pauli string to sympy Pauli algebra objects.
-    #map_to_paulis = {"I": Identity(1), "X": Pauli(1), "Y": Pauli(2), "Z": Pauli(3)}
     map_to_paulis = {
         "I": Matrix([[1, 0], [0, 1]]),
         "X": Matrix([[0, 1], [1, 0]]),


### PR DESCRIPTION
Highlights:
- The best workflow I found to simplify the sympy expressions is to do a `simplify` then a `evalf` on the results.
- Add the `and n_qubits is None` condition to a check in `translate_qubitop`.
- Removed small probabilities from the bitstring dict.

EDIT: Removed `nsimplify` -> switched to `evalf()`.