### PR TITLE
Set the DMET virtual orbital truncation threshold at the user level

### DIFF
--- a/tangelo/problem_decomposition/dmet/_helpers/dmet_bath.py
+++ b/tangelo/problem_decomposition/dmet/_helpers/dmet_bath.py
@@ -122,8 +122,7 @@ def dmet_bath_orb_sort(t_list, e_before, c_before, virtual_orbital_threshold):
     thresh_orb = np.sum(-np.maximum(-e_before, e_before - 2.0)[new_index] > virtual_orbital_threshold)
 
     # Determine the number of bath orbitals
-    sum_tresh_orb = np.sum(thresh_orb)
-    norb = min(sum_tresh_orb, t_list[0])
+    norb = min(np.sum(thresh_orb), t_list[0])
 
     t_list.append(norb)
 

--- a/tangelo/problem_decomposition/dmet/_helpers/dmet_bath.py
+++ b/tangelo/problem_decomposition/dmet/_helpers/dmet_bath.py
@@ -111,12 +111,9 @@ def dmet_bath_orb_sort(t_list, e_before, c_before, virtual_orbital_threshold):
 
     # Sort the orbital energies (Occupation of 1.0 should come first...)
     new_index = np.maximum(-e_before, e_before - 2.0).argsort()
-    print(e_before[new_index])
 
     # Throw away some orbitals above threshold
     thresh_orb = np.sum(-np.maximum(-e_before, e_before - 2.0)[new_index] > virtual_orbital_threshold)
-    print(thresh_orb)
-    print(t_list[0])
 
     # Determine the number of bath orbitals
     sum_tresh_orb = np.sum(thresh_orb)

--- a/tangelo/problem_decomposition/dmet/_helpers/dmet_bath.py
+++ b/tangelo/problem_decomposition/dmet/_helpers/dmet_bath.py
@@ -21,7 +21,7 @@ environment effect from the surrounding part) is done here.
 import numpy as np
 
 
-def dmet_fragment_bath(mol, t_list, temp_list, onerdm_low, virtual_orbital_threshold=1e-13):
+def dmet_fragment_bath(mol, t_list, temp_list, onerdm_low, virtual_orbital_threshold=1e-13, verbose=False):
     """ Construct the bath orbitals for DMET fragment calculation.
 
     Args:
@@ -34,6 +34,8 @@ def dmet_fragment_bath(mol, t_list, temp_list, onerdm_low, virtual_orbital_thres
             calculation (float64).
         virtual_orbital_threshold (float): Occupation threshold for the density
             matrix, used to discard virtual orbitals.
+        verbose (bool): Print the orbital occupancy eigenvalues for prototyping
+            purposes (setting virtual_orbital_threshold).
 
     Returns:
         numpy.array: The bath orbitals (float64).
@@ -46,8 +48,12 @@ def dmet_fragment_bath(mol, t_list, temp_list, onerdm_low, virtual_orbital_thres
     # Diagonalize it
     e, c = np.linalg.eigh(onerdm_embedded)
 
-    # Sort the eigenvectors with the eigenvalues
+    # Sort the eigenvectors with the eigenvalues (should be positive unless
+    # there is numerical noise, therefore we take the absolute values).
     e = np.abs(e)
+    if verbose:
+        print(f"\t{e}\n")
+
     e_sorted, c_sorted = dmet_bath_orb_sort(t_list, e, c, virtual_orbital_threshold)
 
     # Add the core contribution

--- a/tangelo/problem_decomposition/dmet/dmet_problem_decomposition.py
+++ b/tangelo/problem_decomposition/dmet/dmet_problem_decomposition.py
@@ -88,6 +88,7 @@ class DMETProblemDecomposition(ProblemDecomposition):
                            "optimizer": self._default_optimizer,
                            "initial_chemical_potential": 0.0,
                            "solvers_options": list(),
+                           "virtual_orbital_truncation": True,
                            "verbose": False}
 
         self.builtin_localization = set(Localization)
@@ -344,7 +345,7 @@ class DMETProblemDecomposition(ProblemDecomposition):
             temp_list = self.orb_list2[i]
 
             # Construct bath orbitals.
-            bath_orb, e_occupied = helpers._fragment_bath(self.orbitals.mol_full, t_list, temp_list, self.onerdm_low)
+            bath_orb, e_occupied = helpers._fragment_bath(self.orbitals.mol_full, t_list, temp_list, self.onerdm_low, self.virtual_orbital_truncation)
 
             # Obtain one particle rdm for a fragment.
             norb_high, nelec_high, onerdm_high = helpers._fragment_rdm(t_list, bath_orb, e_occupied,

--- a/tangelo/problem_decomposition/dmet/dmet_problem_decomposition.py
+++ b/tangelo/problem_decomposition/dmet/dmet_problem_decomposition.py
@@ -352,7 +352,8 @@ class DMETProblemDecomposition(ProblemDecomposition):
                 print(f"\tSCF Occupancy Eigenvalues for Fragment Number : # {i}")
 
             # Construct bath orbitals.
-            bath_orb, e_occupied = helpers._fragment_bath(self.orbitals.mol_full, t_list, temp_list, self.onerdm_low, self.virtual_orbital_threshold, self.verbose)
+            bath_orb, e_occupied = helpers._fragment_bath(self.orbitals.mol_full, t_list, temp_list,
+                                                          self.onerdm_low, self.virtual_orbital_threshold, self.verbose)
 
             # Obtain one particle rdm for a fragment.
             norb_high, nelec_high, onerdm_high = helpers._fragment_rdm(t_list, bath_orb, e_occupied,

--- a/tangelo/problem_decomposition/dmet/dmet_problem_decomposition.py
+++ b/tangelo/problem_decomposition/dmet/dmet_problem_decomposition.py
@@ -348,8 +348,11 @@ class DMETProblemDecomposition(ProblemDecomposition):
             t_list.append(norb)
             temp_list = self.orb_list2[i]
 
+            if self.verbose:
+                print(f"\tSCF Occupancy Eigenvalues for Fragment Number : # {i}")
+
             # Construct bath orbitals.
-            bath_orb, e_occupied = helpers._fragment_bath(self.orbitals.mol_full, t_list, temp_list, self.onerdm_low, self.virtual_orbital_threshold)
+            bath_orb, e_occupied = helpers._fragment_bath(self.orbitals.mol_full, t_list, temp_list, self.onerdm_low, self.virtual_orbital_threshold, self.verbose)
 
             # Obtain one particle rdm for a fragment.
             norb_high, nelec_high, onerdm_high = helpers._fragment_rdm(t_list, bath_orb, e_occupied,

--- a/tangelo/problem_decomposition/dmet/dmet_problem_decomposition.py
+++ b/tangelo/problem_decomposition/dmet/dmet_problem_decomposition.py
@@ -69,6 +69,10 @@ class DMETProblemDecomposition(ProblemDecomposition):
             options. If only a single dictionary is passed, the same options are
             applied for every solver. This will raise an error if different
             solvers are parsed.
+        virtual_orbital_threshold (float): Occupation threshold for the virtual
+            orbital space. Setting it to 0. is the equivalent of turning off
+            the virtual orbital space truncation.
+            Default=1e-13.
         verbose (bool) : Flag for DMET verbosity.
     """
 
@@ -88,7 +92,7 @@ class DMETProblemDecomposition(ProblemDecomposition):
                            "optimizer": self._default_optimizer,
                            "initial_chemical_potential": 0.0,
                            "solvers_options": list(),
-                           "virtual_orbital_truncation": True,
+                           "virtual_orbital_threshold": 1e-13,
                            "verbose": False}
 
         self.builtin_localization = set(Localization)
@@ -345,7 +349,7 @@ class DMETProblemDecomposition(ProblemDecomposition):
             temp_list = self.orb_list2[i]
 
             # Construct bath orbitals.
-            bath_orb, e_occupied = helpers._fragment_bath(self.orbitals.mol_full, t_list, temp_list, self.onerdm_low, self.virtual_orbital_truncation)
+            bath_orb, e_occupied = helpers._fragment_bath(self.orbitals.mol_full, t_list, temp_list, self.onerdm_low, self.virtual_orbital_threshold)
 
             # Obtain one particle rdm for a fragment.
             norb_high, nelec_high, onerdm_high = helpers._fragment_rdm(t_list, bath_orb, e_occupied,


### PR DESCRIPTION
Highlights:
- Make a `virtual_orbital_threshold` available. Before, it was hard-coded at `1e-13`. Changing this value gives us the ability of trading virtual orbital truncation and DMET energy accuracy. This is especially useful when working with small basis sets.
- Add a verbose print to output the occupancy eigenvalues (those are compared to the threshold).
- Force the occupancy eigenvalues to their absolute value (may be negative due to numerical noise, and this was introducing inconsistencies).