### PR TITLE
Trim bug

### DIFF
--- a/tangelo/toolboxes/operators/tests/test_trim_trivial_qubits.py
+++ b/tangelo/toolboxes/operators/tests/test_trim_trivial_qubits.py
@@ -91,10 +91,10 @@ class TrimTrivialQubits(unittest.TestCase):
         """ Test if trim trivial qubit function produces correct and compatible circuits and operators """
 
         circ = Circuit(mf_gates + pauli_words_gates, n_qubits=12)
-        trimmed_operator, trimmed_circuit = trim_trivial_qubits(qb_ham, circ)
-        self.assertAlmostEqual(np.min(np.linalg.eigvalsh(qubit_operator_sparse(trimmed_operator).todense())), ref_value, places=5)
+        trimmed_operator, trimmed_circuit = trim_trivial_qubits(qb_ham+QubitOperator("Z10"), circ)
+        self.assertAlmostEqual(np.min(np.linalg.eigvalsh(qubit_operator_sparse(trimmed_operator).todense())), ref_value+1, places=5)
         self.assertEqual(ref_circ._gates, trimmed_circuit._gates)
-        self.assertAlmostEqual(sim.get_expectation_value(trimmed_operator, trimmed_circuit), ref_value, places=5)
+        self.assertAlmostEqual(sim.get_expectation_value(trimmed_operator, trimmed_circuit), ref_value+1, places=5)
 
 
 if __name__ == "__main__":

--- a/tangelo/toolboxes/operators/tests/test_trim_trivial_qubits.py
+++ b/tangelo/toolboxes/operators/tests/test_trim_trivial_qubits.py
@@ -87,6 +87,15 @@ class TrimTrivialQubits(unittest.TestCase):
         self.assertEqual(ref_circ._gates, trimmed_circuit._gates)
         self.assertAlmostEqual(sim.get_expectation_value(trimmed_operator, trimmed_circuit), ref_value, places=5)
 
+    def test_trim_trivial_qubits(self):
+        """ Test if trim trivial qubit function produces correct and compatible circuits and operators """
+
+        circ = Circuit(mf_gates + pauli_words_gates, n_qubits=12)
+        trimmed_operator, trimmed_circuit = trim_trivial_qubits(qb_ham, circ)
+        self.assertAlmostEqual(np.min(np.linalg.eigvalsh(qubit_operator_sparse(trimmed_operator).todense())), ref_value, places=5)
+        self.assertEqual(ref_circ._gates, trimmed_circuit._gates)
+        self.assertAlmostEqual(sim.get_expectation_value(trimmed_operator, trimmed_circuit), ref_value, places=5)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tangelo/toolboxes/operators/trim_trivial_qubits.py
+++ b/tangelo/toolboxes/operators/trim_trivial_qubits.py
@@ -104,10 +104,13 @@ def trim_trivial_circuit(circuit):
     # Split circuit and get relevant indices
     circs = circuit.split()
     e_indices = circuit.get_entangled_indices()
+    used_qubits = set()
+    for eq in e_indices:
+        used_qubits.update(eq)
 
     # Find qubits with no gates applied to them, store qubit index and state |0>
     trim_states = {}
-    for qubit_idx in set(range(circuit.width)) - set(circuit._qubit_indices):
+    for qubit_idx in set(range(circuit.width)) - used_qubits:
         trim_states[qubit_idx] = 0
 
     circuit_new = Circuit()
@@ -150,7 +153,8 @@ def trim_trivial_circuit(circuit):
                     circuit_new += circ
             else:
                 circuit_new += circ
-    return circuit_new, trim_states
+
+    return circuit_new, dict(sorted(trim_states.items()))
 
 
 def trim_trivial_qubits(operator, circuit):


### PR DESCRIPTION
When a user specified n_qubits in a Circuit, `trim_trivial_qubits` did not remove qubits from the operator that had no gates operating on them. 