### PR TITLE
Change multi-controlled CNOT to multi-controlled CX

### DIFF
--- a/tangelo/linq/tests/test_translator_circuit.py
+++ b/tangelo/linq/tests/test_translator_circuit.py
@@ -20,7 +20,6 @@
 import unittest
 import os
 import numpy as np
-import time
 
 from tangelo.linq import Gate, Circuit
 from tangelo.linq.gate import PARAMETERIZED_GATES
@@ -141,7 +140,7 @@ class TranslateCircuitTest(unittest.TestCase):
         """
 
         import qiskit
-        from qiskit.providers.aer import AerSimulator
+        from qiskit_aer import AerSimulator
 
         # Generate the qiskit circuit by translating from the abstract one and print it
         translated_circuit = translate_c(abs_circ, "qiskit")
@@ -175,20 +174,6 @@ class TranslateCircuitTest(unittest.TestCase):
 
         # Generate the qiskit circuit by translating from the abstract one and print it
         translated_circuit = translate_c(big_circuit, "qiskit")
-
-        # Big translate/translate back test (32000 gates)
-        very_big_circuit = big_circuit*10**3
-        tstart1 = time.time()
-        qc_very_big_circuit = translate_c(very_big_circuit, "qiskit")
-        tstop1 = time.time()
-        print(f"Circuit -> QuantumCircuit took {tstop1-tstart1:.2f} s")
-
-        tstart2 = time.time()
-        c_very_big_circuit = translate_c(qc_very_big_circuit, "tangelo", source="qiskit")
-        tstop2 = time.time()
-        print(f"QuantumCircuit -> Circuit took {tstop2-tstart2:.2f} s")
-
-        self.assertEqual(c_very_big_circuit, very_big_circuit)
 
         # Simulate both circuits, assert state vectors are equal
         qiskit_simulator = AerSimulator(method="statevector")

--- a/tangelo/linq/tests/test_translator_circuit.py
+++ b/tangelo/linq/tests/test_translator_circuit.py
@@ -34,7 +34,7 @@ abs_circ = Circuit(gates) + Circuit([Gate("RX", 1, parameter=2.)])
 multi_controlled_gates = [Gate("X", 0), Gate("X", 1), Gate("CX", target=2, control=[0, 1])]
 multi_controlled_gates2 = [Gate("X", 0), Gate("X", 1), Gate("CNOT", target=2, control=[0, 1])]
 abs_multi_circ = Circuit(multi_controlled_gates)
-abs_multi_circ2 = Circuit(multi_controlled_gates)
+abs_multi_circ2 = Circuit(multi_controlled_gates2)
 init_gates = [Gate('H', 0), Gate('X', 1), Gate('H', 2)]
 one_qubit_gate_names = ["H", "X", "Y", "Z", "S", "T", "RX", "RY", "RZ", "PHASE"]
 one_qubit_gates = [Gate(name, target=0) if name not in PARAMETERIZED_GATES else Gate(name, target=0, parameter=0.5)
@@ -100,7 +100,7 @@ class TranslateCircuitTest(unittest.TestCase):
         state1 = qulacs.QuantumState(abs_multi_circ.width)
         translated_circuit.update_quantum_state(state1)
 
-        # Generates the qulacs circuit by translating from the abstract one
+        # The same test from above but when a user specifies a multi-controlled CNOT, switches to multi-controlled X
         translated_circuit = translate_c(abs_multi_circ2, "qulacs")
 
         # Run the simulation
@@ -232,7 +232,6 @@ class TranslateCircuitTest(unittest.TestCase):
         np.testing.assert_array_equal(v1, v2)
 
         translated_circuit = translate_c(abs_multi_circ, "cirq")
-        translated_circuit2 = translate_c(abs_multi_circ2, "cirq")
         circ = cirq.Circuit()
         circ.append(cirq.X(qubit_labels[0]))
         circ.append(cirq.X(qubit_labels[1]))
@@ -247,6 +246,9 @@ class TranslateCircuitTest(unittest.TestCase):
 
         np.testing.assert_array_equal(v1, v2)
 
+        # Translator changes abs_multi_circ2 from multi-controlled CNOT into multi-controlled X to be the same as abs_multi_circ
+        # The same statevector is expected.
+        translated_circuit2 = translate_c(abs_multi_circ2, "cirq")
         job_sim = cirq_simulator.simulate(translated_circuit2)
         v2 = job_sim.final_state_vector
 
@@ -286,7 +288,7 @@ class TranslateCircuitTest(unittest.TestCase):
         translated_circuit = translate_c(abs_multi_circ, "qdk")
         print(translated_circuit)
 
-        # Check that multi-controlled CNOT is changed correctly to "CX"
+        # Check that multi-controlled CNOT is changed correctly to multi-controlled "CX"
         translated_circuit2 = translate_c(abs_multi_circ2, "qdk")
         self.assertEqual(translated_circuit, translated_circuit2)
 

--- a/tangelo/linq/tests/test_translator_circuit.py
+++ b/tangelo/linq/tests/test_translator_circuit.py
@@ -68,7 +68,7 @@ class TranslateCircuitTest(unittest.TestCase):
             VS one obtained through translation from an abstract format
         """
         import qulacs
-        
+
         # Test 1: Simulation of trasnlated circuit VS native circuit
         # Generates the qulacs circuit by translating from the abstract one, run the simulation afterwards
         translated_circuit = translate_c(abs_circ, "qulacs")
@@ -88,9 +88,9 @@ class TranslateCircuitTest(unittest.TestCase):
         # Run the simulation of the native qulacs circuit, assert state vectors are identical
         state2 = qulacs.QuantumState(abs_circ.width)
         qulacs_circuit.update_quantum_state(state2)
-        
+
         np.testing.assert_array_equal(state1.get_vector(), state2.get_vector())
-        
+
         # Test 2: Multi-controlled CNOT and multi-controlled X test
         translated_circuit = translate_c(abs_multi_circ, "qulacs")
         state1 = qulacs.QuantumState(abs_multi_circ.width)
@@ -107,7 +107,7 @@ class TranslateCircuitTest(unittest.TestCase):
         mat_gate.add_control_qubit(0, 1)
         mat_gate.add_control_qubit(1, 1)
         qulacs_circuit.add_gate(mat_gate)
-        
+
         # Run, assert state vectors are equal.
         state2 = qulacs.QuantumState(abs_multi_circ.width)
         qulacs_circuit.update_quantum_state(state2)

--- a/tangelo/linq/translator/translate_cirq.py
+++ b/tangelo/linq/translator/translate_cirq.py
@@ -108,9 +108,11 @@ def translate_c_to_cirq(source_circuit, noise_model=None, save_measurements=Fals
 
     # Maps the gate information properly. Different for each backend (order, values)
     for gate in source_circuit._gates:
-        if (gate.control is not None) and gate.name != 'CNOT':
+        if gate.control is not None:
             num_controls = len(gate.control)
             control_list = [qubit_list[c] for c in gate.control]
+            if gate.name == 'CNOT' and num_controls > 1:
+                gate.name = 'CX'
         if gate.name in {"H", "X", "Y", "Z", "S", "T"}:
             target_circuit.append(GATE_CIRQ[gate.name](qubit_list[gate.target[0]]))
         elif gate.name in {"CH", "CX", "CY", "CZ"}:

--- a/tangelo/linq/translator/translate_qdk.py
+++ b/tangelo/linq/translator/translate_qdk.py
@@ -97,11 +97,13 @@ def translate_c_to_qsharp(source_circuit, operation="MyQsharpOperation", save_me
     # Generate Q# strings with the right syntax, order and values for the gate inputs
     body_str = ""
     for gate in source_circuit._gates:
-        if gate.control is not None and gate.name != "CNOT":
+        if gate.control is not None:
             control_string = '['
             num_controls = len(gate.control)
             for i, c in enumerate(gate.control):
                 control_string += f'qreg[{c}]]' if i == num_controls - 1 else f'qreg[{c}], '
+            if num_controls > 1 and gate.name == 'CNOT':
+                gate.name = 'CX'
 
         if gate.name in {"H", "X", "Y", "Z", "S", "T"}:
             body_str += f"\t\t{GATE_QDK[gate.name]}(qreg[{gate.target[0]}]);\n"

--- a/tangelo/linq/translator/translate_qulacs.py
+++ b/tangelo/linq/translator/translate_qulacs.py
@@ -108,6 +108,8 @@ def translate_c_to_qulacs(source_circuit, noise_model=None, save_measurements=Fa
 
     # Maps the gate information properly. Different for each backend (order, values)
     for gate in source_circuit._gates:
+        if gate.name == 'CNOT' and len(gate.control) > 1:
+            gate.name = 'CX'
         if gate.name in {"H", "X", "Y", "Z", "S", "T"}:
             (GATE_QULACS[gate.name])(target_circuit, gate.target[0])
         elif gate.name in {"CH", "CX", "CY", "CZ"}:


### PR DESCRIPTION
Previously CNOT ignored all controls except the first without warning. This changes the name in the circuit to CX.