### PR TITLE
Support for UMP2 initial parameters

### DIFF
--- a/tangelo/algorithms/classical/mp2_solver.py
+++ b/tangelo/algorithms/classical/mp2_solver.py
@@ -52,7 +52,7 @@ class MP2Solver(ElectronicStructureSolver):
 
         if self.spin != 0 or self.uhf:
             self.n_alpha, self.n_beta = molecule.n_active_ab_electrons
-            self.n_active_moa, self.n_active_mob = molecule.n_active_mos if self.uhf else (molecule.n_active_mos, molecule.n_active_mos)
+            self.n_active_moa, self.n_active_mob = molecule.n_active_mos if self.uhf else (molecule.n_active_mos,)*2
         else:
             self.n_occupied = ceil(molecule.n_active_electrons / 2)
             self.n_virtual = molecule.n_active_mos - self.n_occupied

--- a/tangelo/algorithms/classical/mp2_solver.py
+++ b/tangelo/algorithms/classical/mp2_solver.py
@@ -92,9 +92,9 @@ class MP2Solver(ElectronicStructureSolver):
 
         # Check if MP2 has been performed
         if self.mp2_fragment is None:
-            raise RuntimeError(f"{self.__class__.name}: Cannot retrieve RDM. Please run the 'simulate' method first")
+            raise RuntimeError(f"{self.__class__.__name__}: Cannot retrieve RDM. Please run the 'simulate' method first")
         if self.frozen is not None:
-            raise RuntimeError(f"{self.__class__.name}: RDM calculation is not implemented with frozen orbitals.")
+            raise RuntimeError(f"{self.__class__.__name__}: RDM calculation is not implemented with frozen orbitals.")
 
         one_rdm = self.mp2_fragment.make_rdm1()
         two_rdm = self.mp2_fragment.make_rdm2()
@@ -113,7 +113,7 @@ class MP2Solver(ElectronicStructureSolver):
 
         # Check if MP2 has been performed.
         if self.mp2_fragment is None:
-            raise RuntimeError(f"{self.__class__.name}: Cannot retrieve MP2 parameters. Please run the 'simulate' method first")
+            raise RuntimeError(f"{self.__class__.__name__}: Cannot retrieve MP2 parameters. Please run the 'simulate' method first")
 
         if self.spin != 0 or self.uhf:
             # Reorder the T2 amplitudes in a dense list.

--- a/tangelo/algorithms/classical/mp2_solver.py
+++ b/tangelo/algorithms/classical/mp2_solver.py
@@ -102,10 +102,10 @@ class MP2Solver(ElectronicStructureSolver):
         return one_rdm, two_rdm
 
     def get_mp2_amplitudes(self):
-        """Compute the double amplitudes from the perturbative method, and then
-        reorders the elements into the appropriate convention. The single (T1)
-        amplitudes are set to a small non-zero value. The ordering is single,
-        double (diagonal), double (non-diagonal).
+        """Compute the double amplitudes from the MP2 perturbative method, and
+        then reorder the elements into a dense list. The single (T1) amplitudes
+        are set to a small non-zero value. The ordering is single, double
+        (diagonal), double (non-diagonal).
 
         Returns:
             list of float: The electronic excitation amplitudes.

--- a/tangelo/algorithms/classical/tests/test_mp2_solver.py
+++ b/tangelo/algorithms/classical/tests/test_mp2_solver.py
@@ -62,8 +62,8 @@ class MP2SolverTest(unittest.TestCase):
         self.assertAlmostEqual(energy, -14.5092873, places=6)
 
     def test_get_mp2_params_restricted(self):
-        """Test the packing of RMP2 amplitudes as intial parameter for UCC
-        methods.
+        """Test the packing of RMP2 amplitudes as initial parameters for coupled
+        cluster based methods.
         """
 
         solver = MP2Solver(mol_H2_sto3g)
@@ -74,8 +74,8 @@ class MP2SolverTest(unittest.TestCase):
         np.testing.assert_array_almost_equal(ref_params, solver.get_mp2_params())
 
     def test_get_mp2_params_unrestricted(self):
-        """Test the packing of UMP2 amplitudes as intial parameter for UCC-like
-        methods.
+        """Test the packing of UMP2 amplitudes as initial parameters for coupled
+        cluster based methods.
         """
 
         solver = MP2Solver(mol_H2_sto3g_uhf)

--- a/tangelo/algorithms/classical/tests/test_mp2_solver.py
+++ b/tangelo/algorithms/classical/tests/test_mp2_solver.py
@@ -14,8 +14,10 @@
 
 import unittest
 
+import numpy as np
+
 from tangelo.algorithms.classical import MP2Solver
-from tangelo.molecule_library import mol_H2_321g, mol_Be_321g, mol_H4_cation_sto3g
+from tangelo.molecule_library import mol_H2_321g, mol_Be_321g, mol_H2_sto3g, mol_H2_sto3g_uhf
 
 
 class MP2SolverTest(unittest.TestCase):
@@ -58,6 +60,29 @@ class MP2SolverTest(unittest.TestCase):
         energy = solver.simulate()
 
         self.assertAlmostEqual(energy, -14.5092873, places=6)
+
+    def test_get_mp2_params_restricted(self):
+        """Test the packing of RMP2 amplitudes as intial parameter for UCC
+        methods.
+        """
+
+        solver = MP2Solver(mol_H2_sto3g)
+        solver.simulate()
+
+        ref_params = [2.e-05, 3.632537e-02]
+
+        np.testing.assert_array_almost_equal(ref_params, solver.get_mp2_params())
+
+    def test_get_mp2_params_unrestricted(self):
+        """Test the packing of UMP2 amplitudes as intial parameter for UCC-like
+        methods.
+        """
+
+        solver = MP2Solver(mol_H2_sto3g_uhf)
+        solver.simulate()
+        ref_params = [0., 0., 0.030736]
+
+        np.testing.assert_array_almost_equal(ref_params, solver.get_mp2_params())
 
 
 if __name__ == "__main__":

--- a/tangelo/algorithms/classical/tests/test_mp2_solver.py
+++ b/tangelo/algorithms/classical/tests/test_mp2_solver.py
@@ -71,7 +71,7 @@ class MP2SolverTest(unittest.TestCase):
 
         ref_params = [2.e-05, 3.632537e-02]
 
-        np.testing.assert_array_almost_equal(ref_params, solver.get_mp2_params())
+        np.testing.assert_array_almost_equal(ref_params, solver.get_mp2_amplitudes())
 
     def test_get_mp2_params_unrestricted(self):
         """Test the packing of UMP2 amplitudes as initial parameters for coupled
@@ -82,7 +82,7 @@ class MP2SolverTest(unittest.TestCase):
         solver.simulate()
         ref_params = [0., 0., 0.030736]
 
-        np.testing.assert_array_almost_equal(ref_params, solver.get_mp2_params())
+        np.testing.assert_array_almost_equal(ref_params, solver.get_mp2_amplitudes())
 
 
 if __name__ == "__main__":

--- a/tangelo/toolboxes/ansatz_generator/uccsd.py
+++ b/tangelo/toolboxes/ansatz_generator/uccsd.py
@@ -251,12 +251,9 @@ class UCCSD(Ansatz):
         return qubit_op
 
     def _compute_mp2_params(self):
-        """Computes the MP2 initial variational parameters. Compute the initial
-        variational parameters with PySCF MP2 calculation, and then reorders the
-        elements into the appropriate convention. MP2 only has doubles (T2)
-        amplitudes, thus the single (T1) amplitudes are set to a small non-zero
-        value and added. The ordering is single, double (diagonal), double
-        (non-diagonal).
+        """Compute the MP2 initial variational parameters. Only double
+        excitation amplitudes are retrieved from an MP2 calculation (singles
+        set to a small number close to 0).
 
         Returns:
             list of float: The initial variational parameters.

--- a/tangelo/toolboxes/ansatz_generator/uccsd.py
+++ b/tangelo/toolboxes/ansatz_generator/uccsd.py
@@ -277,4 +277,4 @@ class UCCSD(Ansatz):
         mp2 = MP2Solver(pymol)
         mp2.simulate()
 
-        return mp2.get_mp2_params()
+        return mp2.get_mp2_amplitudes()

--- a/tangelo/toolboxes/ansatz_generator/uccsd.py
+++ b/tangelo/toolboxes/ansatz_generator/uccsd.py
@@ -99,7 +99,6 @@ class UCCSD(Ansatz):
         self.supported_initial_var_params = {"ones", "random", "mp2"}
 
         # Default initial parameters for initialization
-        # TODO: support for openshell MP2 initialization
         self.var_params_default = "mp2"
         self.reference_state = reference_state
 

--- a/tangelo/toolboxes/ansatz_generator/uccsd.py
+++ b/tangelo/toolboxes/ansatz_generator/uccsd.py
@@ -251,8 +251,12 @@ class UCCSD(Ansatz):
         return qubit_op
 
     def _compute_mp2_params(self):
-        """Computes the MP2 initial variational parameters. The request is made
-        via the MP2Solver class.
+        """Computes the MP2 initial variational parameters. Compute the initial
+        variational parameters with PySCF MP2 calculation, and then reorders the
+        elements into the appropriate convention. MP2 only has doubles (T2)
+        amplitudes, thus the single (T1) amplitudes are set to a small non-zero
+        value and added. The ordering is single, double (diagonal), double
+        (non-diagonal).
 
         Returns:
             list of float: The initial variational parameters.


### PR DESCRIPTION
Support for initial MP2 parameters with a UHF mean-field.

Highlights:
- Support UMP2 initial parameters via `pyscf.mp.UMP2`.
- Moved the computation of MP2 parameters to the `MP2Solver` class (was in `UCCSD` before).
- Fixed a circular import when doing `from tangelo.toolboxes.ansatz_generator._unitary_cc_openshell import uccsd_openshell_get_packed_amplitudes` by moving the `MP2Solver` import after the initialiazation of the `UCCSD` ansatz.