### PR TITLE
DMET Effective Core Potential fix(related to #306)

### DIFF
--- a/tangelo/problem_decomposition/dmet/_helpers/dmet_orbitals.py
+++ b/tangelo/problem_decomposition/dmet/_helpers/dmet_orbitals.py
@@ -100,6 +100,7 @@ class dmet_orbitals:
             low_scf_dm = self.mf_full.mo_coeff @ np.diag(self.mf_full.mo_occ) @ self.mf_full.mo_coeff.T
             low_scf_twoint = self.pyscfscf.hf.get_veff(self.mf_full.mol, low_scf_dm, 0, 0, 1)
             self.low_scf_fock = self.mf_full.mol.intor("cint1e_kin_sph") + self.mf_full.mol.intor("cint1e_nuc_sph") + low_scf_twoint
+            # Add effective core potential to Fock matrix if applicable.
             if len(self.mol_full._ecpbas) > 0:
                 self.low_scf_fock += self.mf_full.mol.intor_symmetric('ECPscalar')
 

--- a/tangelo/problem_decomposition/dmet/_helpers/dmet_orbitals.py
+++ b/tangelo/problem_decomposition/dmet/_helpers/dmet_orbitals.py
@@ -100,6 +100,8 @@ class dmet_orbitals:
             low_scf_dm = self.mf_full.mo_coeff @ np.diag(self.mf_full.mo_occ) @ self.mf_full.mo_coeff.T
             low_scf_twoint = self.pyscfscf.hf.get_veff(self.mf_full.mol, low_scf_dm, 0, 0, 1)
             self.low_scf_fock = self.mf_full.mol.intor("cint1e_kin_sph") + self.mf_full.mol.intor("cint1e_nuc_sph") + low_scf_twoint
+            if len(self.mol_full._ecpbas) > 0:
+                self.low_scf_fock += self.mf_full.mol.intor_symmetric('ECPscalar')
 
             # Define the core space if possible (Initial calculations treat the entire molecule ...).
             core_mo_dm = np.array(self.mf_full.mo_occ, copy=True)

--- a/tangelo/problem_decomposition/dmet/dmet_problem_decomposition.py
+++ b/tangelo/problem_decomposition/dmet/dmet_problem_decomposition.py
@@ -118,7 +118,7 @@ class DMETProblemDecomposition(ProblemDecomposition):
         # Converting our interface to pyscf.mol.gto and pyscf.scf (used by this
         # code).
         self.mean_field = self.molecule.mean_field
-        self.molecule = mol_to_pyscf(self.molecule, self.molecule.basis)
+        self.molecule = mol_to_pyscf(self.molecule, self.molecule.basis, ecp=self.molecule.ecp)
 
         # If fragment_atoms is detected as a nested list of int, atoms are reordered to be
         # consistent with a list of numbers representing the number of atoms in each fragment.

--- a/tangelo/problem_decomposition/tests/dmet/test_dmet.py
+++ b/tangelo/problem_decomposition/tests/dmet/test_dmet.py
@@ -15,6 +15,7 @@
 import unittest
 import numpy as np
 
+from tangelo import SecondQuantizedMolecule
 from tangelo.molecule_library import mol_H4_doublecation_minao, mol_H4_doublecation_321g, mol_H10_321g, mol_H10_minao
 from tangelo.problem_decomposition import DMETProblemDecomposition
 from tangelo.problem_decomposition.dmet import Localization
@@ -260,6 +261,17 @@ class DMETProblemDecompositionTest(unittest.TestCase):
         solver.build()
         energy = solver.simulate()
         self.assertAlmostEqual(energy, -4.41503, places=4)
+
+    def test_dmet_ecp(self):
+        """Tests the DMET energy for Zn with ECP."""
+        mol_zn = SecondQuantizedMolecule("Zn", q=2, spin=0, basis="lanl2dz", ecp="lanl2dz")
+
+        options_zn_dmet = {"molecule": mol_zn, "fragment_atoms": [1], "fragment_solvers": "ccsd"}
+
+        solver = DMETProblemDecomposition(options_zn_dmet)
+        solver.build()
+        energy = solver.simulate()
+        self.assertAlmostEqual(energy, -62.77176, places=4)
 
     def test_dmet_wrong_number_frozen_orbitals(self):
         """Tests if the program raises the error when the number of frozen


### PR DESCRIPTION
Should fix #306 

Previously the Effective Core Potential term was not added to the fragment Fock matrix for RHF systems in DMETProblemDecomposition. This PR addresses that issue and adds a test to show that it is correctly returning the expected answer as described in #306.