### PR TITLE
improved Error message for MP2 initialization

### DIFF
--- a/tangelo/toolboxes/ansatz_generator/uccsd.py
+++ b/tangelo/toolboxes/ansatz_generator/uccsd.py
@@ -263,8 +263,9 @@ class UCCSD(Ansatz):
             supported_initial_var_params = self.supported_initial_var_params.copy()
             supported_initial_var_params.remove("mp2")
             raise ValueError(f"PySCF is required for MP2 initial parameters in {self.__class__.__name__}.\n"
-                             f"Other available initializations are 'initial_var_params': {supported_initial_var_params} "
-                             f"or an array of length {self.n_var_params}.")
+                             f"Other supported keywords for initializing variational parameters are {supported_initial_var_params}. "
+                             f"An array of floats of length {self.n_var_params} can also be provided.\n"
+                             f"The above keywords or array can also be provided to variational algorithms through the 'initial_var_params' keyword.")
 
         # Import here to solve an AttributeError: partially initialized module
         # tangelo.toolboxes.ansatz_generator' has no attribute 'UCCSD'

--- a/tangelo/toolboxes/ansatz_generator/uccsd.py
+++ b/tangelo/toolboxes/ansatz_generator/uccsd.py
@@ -260,7 +260,11 @@ class UCCSD(Ansatz):
         """
 
         if not is_package_installed("pyscf"):
-            raise ValueError(f"pyscf is required for MP2 initial parameters in {self.__class__.__name__}.")
+            supported_initial_var_params = self.supported_initial_var_params.copy()
+            supported_initial_var_params.remove("mp2")
+            raise ValueError(f"PySCF is required for MP2 initial parameters in {self.__class__.__name__}.\n"
+                             f"Other available initializations are 'initial_var_params': {supported_initial_var_params} "
+                             f"or an array of length {self.n_var_params}.")
 
         # Import here to solve an AttributeError: partially initialized module
         # tangelo.toolboxes.ansatz_generator' has no attribute 'UCCSD'


### PR DESCRIPTION
Right now. If someone uses psi4 to call VQESolver with default parameters, a generic error message is received when building.
```python3
from tangelo.algorithms.variational import VQESolver
from tangelo.molecule_library import mol_H4_sto3g
vqe = VQESolver({"molecule": mol_H4_sto3g})
vqe.build()
```
results in
```
ValueError: "PySCF is required for MP2 initial parameters in UCCSD"
```

Added information about other var_param options. Now results in:
```
ValueError: PySCF is required for MP2 initial parameters in UCCSD.
Other supported keywords for initializing variational parameters are {'random', 'ones'}. An array of length 14 can also be provided.
The above options can also be provided to variational algorithms through the 'initial_var_params' keyword.
```