### PR TITLE
Fixed requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,4 @@
 import setuptools
-import sys
-import subprocess
-import os
 
 with open("tangelo/_version.py") as f:
     version = f.readlines()[-1].split()[-1].strip("\"'")

--- a/setup.py
+++ b/setup.py
@@ -3,18 +3,11 @@ import sys
 import subprocess
 import os
 
-
-def install(package):
-    subprocess.check_call([sys.executable, "-m", "pip", "install", package])
-
-
 with open("tangelo/_version.py") as f:
     version = f.readlines()[-1].split()[-1].strip("\"'")
 
 with open('README.rst', 'r') as f:
     long_description = f.read()
-
-install('wheel')
 
 description = "Maintained by Good Chemistry Company, focusing on the development of end-to-end materials simulation workflows on quantum computers."
 
@@ -24,10 +17,8 @@ setuptools.setup(
     version=version,
     description=description,
     long_description=description,
-    # long_description_content_type=description,
     url="https://github.com/goodchemistryco/Tangelo",
     packages=setuptools.find_packages(),
     test_suite="tangelo",
-    setup_requires=['h5py'],
-    install_requires=['h5py', 'bitarray', 'openfermion']
+    install_requires=['h5py', 'bitarray', 'openfermion', 'openfermionpyscf', 'pyscf', 'pyscf-semiempirical']
 )

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     author="The Tangelo developers",
     version=version,
     description=description,
-    long_description=description,
+    long_description=long_description,
     url="https://github.com/goodchemistryco/Tangelo",
     packages=setuptools.find_packages(),
     test_suite="tangelo",

--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,8 @@ setuptools.setup(
     url="https://github.com/goodchemistryco/Tangelo",
     packages=setuptools.find_packages(),
     test_suite="tangelo",
-    install_requires=['h5py', 'bitarray', 'openfermion', 'pyscf', 'pyscf-semiempirical']
+    install_requires=['h5py', 'bitarray', 'openfermion'],
+    extras_require={
+        'pyscf': ['pyscf', 'pyscf-semiempirical @ git+https://github.com/pyscf/semiempirical@v0.1.0'], # pyscf-semiempirical PyPI sdist is missing C extension files
+    }
 )

--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,5 @@ setuptools.setup(
     url="https://github.com/goodchemistryco/Tangelo",
     packages=setuptools.find_packages(),
     test_suite="tangelo",
-    install_requires=['h5py', 'bitarray', 'openfermion', 'openfermionpyscf', 'pyscf', 'pyscf-semiempirical']
+    install_requires=['h5py', 'bitarray', 'openfermion', 'pyscf', 'pyscf-semiempirical']
 )


### PR DESCRIPTION
Added missing requirements `pyscf` and `pyscf-semiempirical` (depends on https://github.com/pyscf/semiempirical/issues/8)
Removed unused setup dep
Removed pre-install dep already handled by setuptools

If deps `'openfermionpyscf', 'pyscf', 'pyscf-semiempirical'` are to be extra, they can be identified as such.