### PR TITLE
Qiskit interface: Bug workaround and PauliSumOp->SparsePauliOp

### DIFF
--- a/tangelo/linq/target/target_qiskit.py
+++ b/tangelo/linq/target/target_qiskit.py
@@ -90,7 +90,7 @@ class QiskitSimulator(Backend):
             "Return statevector and mid-circuit measurement for one shot"
             sim_results = backend.run(translated_circuit, noise_model=qiskit_noise_model, shots=1).result()
             current_state = sim_results.get_statevector(translated_circuit)
-            measure = next(iter(self.qiskit.result.marginal_counts(sim_results, indices=list(range(n_meas))).get_counts()))[::-1]
+            measure = next(iter(self.qiskit.result.marginal_counts(sim_results, indices=list(range(n_meas)), inplace=True).get_counts()))[::-1]
             return current_state, measure
 
         if desired_meas_result is not None and not self._noise_model:

--- a/tangelo/linq/tests/test_translator_qubitop.py
+++ b/tangelo/linq/tests/test_translator_qubitop.py
@@ -49,8 +49,8 @@ class TranslateOperatorTest(unittest.TestCase):
     def test_qiskit_to_tangelo(self):
         """Test translation from a qiskit to a tangelo operator."""
 
-        from qiskit.opflow.primitive_ops import PauliSumOp
-        qiskit_op = PauliSumOp.from_list([("ZYX", 2.), ("III", 3.)])
+        from qiskit.quantum_info.operators import SparsePauliOp
+        qiskit_op = SparsePauliOp.from_list([("ZYX", 2.), ("III", 3.)])
 
         test_op = translate_operator(qiskit_op, source="qiskit", target="tangelo")
         self.assertEqual(test_op, tangelo_op)
@@ -59,8 +59,8 @@ class TranslateOperatorTest(unittest.TestCase):
     def test_tangelo_to_qiskit(self):
         """Test translation from a tangelo to a qiskit operator."""
 
-        from qiskit.opflow.primitive_ops import PauliSumOp
-        qiskit_op = PauliSumOp.from_list([("ZYX", 2.), ("III", 3.)])
+        from qiskit.quantum_info.operators import SparsePauliOp
+        qiskit_op = SparsePauliOp.from_list([("ZYX", 2.), ("III", 3.)])
 
         test_op = translate_operator(tangelo_op, source="tangelo", target="qiskit")
         self.assertEqual(qiskit_op, test_op)
@@ -185,17 +185,14 @@ class TranslateOperatorTest(unittest.TestCase):
     def test_tangelo_to_qiskit_H2_eigenvalues(self):
         """Test eigenvalues resulting from a tangelo to qiskit translation."""
 
-        from qiskit.algorithms import NumPyEigensolver
-
         qu_op = load_operator("H2_JW_occfirst.data", data_directory=pwd_this_test+"/data", plain_text=True)
         test_op = translate_operator(qu_op, source="tangelo", target="qiskit")
 
         eigenvalues_tangelo = eigenspectrum(qu_op)
 
-        qiskit_solver = NumPyEigensolver(2**4)
-        eigenvalues_qiskit = qiskit_solver.compute_eigenvalues(test_op)
+        eigenvalues_qiskit = np.linalg.eigh(test_op.to_matrix(sparse=False))[0]
 
-        np.testing.assert_array_almost_equal(eigenvalues_tangelo, eigenvalues_qiskit.eigenvalues)
+        np.testing.assert_array_almost_equal(eigenvalues_tangelo, eigenvalues_qiskit)
 
 
 if __name__ == "__main__":

--- a/tangelo/linq/translator/translate_qiskit.py
+++ b/tangelo/linq/translator/translate_qiskit.py
@@ -158,18 +158,18 @@ def translate_c_from_qiskit(source_circuit):
 
 def translate_op_to_qiskit(qubit_operator, n_qubits):
     """Helper function to translate a Tangelo QubitOperator to a qiskit
-    PauliSumOp. Qiskit must be installed for the function to work.
+    SparsePauliOp. Qiskit must be installed for the function to work.
 
     Args:
         qubit_operator (tangelo.toolboxes.operators.QubitOperator): Self-explanatory.
         n_qubits (int): Number of qubits relevant to the operator.
 
     Returns:
-        (qiskit.opflow.primitive_ops.PauliSumOp): Qiskit qubit operator.
+        (qiskit.quantum_info.operators.SparsePauliOp): Qiskit qubit operator.
     """
 
     # Import qiskit qubit operator.
-    from qiskit.opflow.primitive_ops import PauliSumOp
+    from qiskit.quantum_info.operators import SparsePauliOp
 
     # Convert each term sequencially.
     term_list = list()
@@ -179,15 +179,15 @@ def translate_op_to_qiskit(qubit_operator, n_qubits):
         # Reverse the string because of qiskit convention.
         term_list += [(term_string[::-1], coeff)]
 
-    return PauliSumOp.from_list(term_list)
+    return SparsePauliOp.from_list(term_list)
 
 
 def translate_op_from_qiskit(qubit_operator):
-    """Helper function to translate a qiskit PauliSumOp to a Tangelo
+    """Helper function to translate a qiskit SparsePauliOp to a Tangelo
     QubitOperator.
 
     Args:
-        qubit_operator (qiskit.opflow.primitive_ops.PauliSumOp): Self-explanatory.
+        qubit_operator (qiskit.quantum_info.operators.SparsePauliOp): Self-explanatory.
 
     Returns:
         (tangelo.toolboxes.operators.QubitOperator): Tangelo qubit operator.
@@ -195,11 +195,11 @@ def translate_op_from_qiskit(qubit_operator):
 
     # Create a dictionary to append all terms at once.
     terms_dict = dict()
-    for pauli_word in qubit_operator:
+    terms = qubit_operator.to_list()
+    for term_string, coeff in terms:
         # Inversion of the string because of qiskit ordering.
-        term_string = pauli_word.to_pauli_op().primitive.to_label()[::-1]
-        term_tuple = pauli_string_to_of(term_string)
-        terms_dict[tuple(term_tuple)] = complex(pauli_word.coeffs)
+        term_tuple = pauli_string_to_of(term_string[::-1])
+        terms_dict[tuple(term_tuple)] = coeff
 
     # Create and copy the information into a new QubitOperator.
     tangelo_op = QubitOperator()


### PR DESCRIPTION
One bug from deepcopy not working anymore with `qiskit.result.marginal_counts` changed to inplace=True. 
We never resample result anyway.

`opflow` is deprecated. `PauliSumOp`->`SparsePauliOp`. See https://qiskit.org/documentation/migration_guides/opflow_migration.html 