### PR TITLE
Adding more python versions to tests

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -7,14 +7,14 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-        fail-fast: false
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -87,18 +87,18 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: tangelo-no-pyscf-test-results
-        path: tangelo/toolboxes/molecular_computation/tests/junit/nopyscf-test-results.xml
+        path: tangelo/toolboxes/molecular_computation/tests/junit/nopyscf-test-results_${{ matrix.python-version }}.xml
 
     - name: Upload pytest test results
       uses: actions/upload-artifact@v3
       with:
         name: tangelo-test-results
-        path: tangelo/junit/tangelo-test-results.xml
+        path: tangelo/junit/tangelo-test-results_${{ matrix.python-version }}.xml
 
     - name: Upload pytest html results
       uses: actions/upload-artifact@v3
       with:
-        name: tangelo-tests-coverage
+        name: tangelo-tests-coverage_${{ matrix.python-version }}
         path: tangelo/htmlcov
       if: always()
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -68,7 +68,7 @@ jobs:
     - name: tangelo no_pyscf tests
       run: |
         cd tangelo/toolboxes/molecular_computation/tests
-        pytest --doctest-modules --junitxml=junit/nopyscf-test-results.xml test_nopyscf.py
+        pytest --doctest-modules --junitxml=junit/nopyscf-test-results_${{ matrix.python-version }}.xml test_nopyscf.py
       if: always()
 
     - name: Install pyscf
@@ -80,7 +80,7 @@ jobs:
     - name: tangelo tests
       run: |
         cd tangelo
-        pytest --doctest-modules --junitxml=junit/tangelo-test-results.xml --cov=. --cov-report=xml --cov-report=html
+        pytest --doctest-modules --junitxml=junit/tangelo-test-results_${{ matrix.python-version }}.xml --cov=. --cov-report=xml --cov-report=html
       if: always()
 
     - name: Upload nopyscf test results

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -9,6 +9,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
+        fail-fast: false
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/run_psi4_test.yml
+++ b/.github/workflows/run_psi4_test.yml
@@ -24,16 +24,13 @@ jobs:
     - run: conda list
     - run: conda config --show
 
-    - name: Display Python version
-      run: python -c "import sys; print(sys.version)"
-
     - name: Install psi4 ${{ matrix.python-version }}
       shell: bash -el {0}
       run: |
         conda install psi4 -c psi4
         conda init
+        python -c "import sys; print(sys.version)"
       if: always()
-      
 
     - name: Install pip, wheel, pytest, jupyter
       run: |

--- a/.github/workflows/run_psi4_test.yml
+++ b/.github/workflows/run_psi4_test.yml
@@ -7,8 +7,9 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: [3.8]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     
     defaults:
       run:
@@ -23,12 +24,16 @@ jobs:
     - run: conda list
     - run: conda config --show
 
-    - name: Install psi4
+    - name: Display Python version
+      run: python -c "import sys; print(sys.version)"
+
+    - name: Install psi4 ${{ matrix.python-version }}
       shell: bash -el {0}
       run: |
-        conda install psi4 python=3.8 -c psi4
+        conda install psi4 -c psi4
         conda init
       if: always()
+      
 
     - name: Install pip, wheel, pytest, jupyter
       run: |
@@ -50,26 +55,26 @@ jobs:
     - name: tangelo psi4 integral tests
       run: |
         cd tangelo/toolboxes/molecular_computation/tests
-        pytest --doctest-modules --junitxml=junit/psi4-test-results.xml test_psi4.py
+        pytest --doctest-modules --junitxml=junit/psi4-test-results_${{ matrix.python-version }}.xml test_psi4.py
       if: always()
 
     - name: tangelo psi4 classical tests
       run: |
         cd tangelo/algorithms/classical/tests
-        pytest --doctest-modules --junitxml=junit/psi4-classical-test-results.xml
+        pytest --doctest-modules --junitxml=junit/psi4-classical-test-results_${{ matrix.python-version }}.xml
       if: always()
 
     - name: Upload psi4 test results
       uses: actions/upload-artifact@v3
       with:
         name: tangelo-psi4-test-results
-        path: tangelo/toolboxes/molecular_computation/tests/junit/psi4-test-results.xml
+        path: tangelo/toolboxes/molecular_computation/tests/junit/psi4-test-results_${{ matrix.python-version }}.xml
 
     - name: Upload classical psi4 test results
       uses: actions/upload-artifact@v3
       with:
         name: tangelo-classical-psi4-test-results
-        path: tangelo/algorithms/classical/tests/junit/psi4-classical-test-results.xml
+        path: tangelo/algorithms/classical/tests/junit/psi4-classical-test-results_${{ matrix.python-version }}.xml
 
     - name: Download all workflow run artifacts
       uses: actions/download-artifact@v3

--- a/.github/workflows/run_psi4_test.yml
+++ b/.github/workflows/run_psi4_test.yml
@@ -27,9 +27,8 @@ jobs:
     - name: Install psi4 ${{ matrix.python-version }}
       shell: bash -el {0}
       run: |
-        conda install psi4 python=${{ matrix.python-version }} -c psi4
+        conda install psi4 python=${{ matrix.python-version }} -c conda-forge/label/libint_dev -c conda-forge
         conda init
-        python -c "import sys; print(sys.version)"
       if: always()
 
     - name: Install pip, wheel, pytest, jupyter

--- a/.github/workflows/run_psi4_test.yml
+++ b/.github/workflows/run_psi4_test.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install psi4 ${{ matrix.python-version }}
       shell: bash -el {0}
       run: |
-        conda install psi4 -c psi4
+        conda install psi4 python=${{ matrix.python-version }}-c psi4
         conda init
         python -c "import sys; print(sys.version)"
       if: always()

--- a/.github/workflows/run_psi4_test.yml
+++ b/.github/workflows/run_psi4_test.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install psi4 ${{ matrix.python-version }}
       shell: bash -el {0}
       run: |
-        conda install psi4 python=${{ matrix.python-version }}-c psi4
+        conda install psi4 python=${{ matrix.python-version }} -c psi4
         conda init
         python -c "import sys; print(sys.version)"
       if: always()


### PR DESCRIPTION
Currently adding (3.9, 3.10, 3.11) to see what happens. We are only running tests on 3.8 so far.