### PR TITLE
Measurement Controlled operations

### DIFF
--- a/tangelo/helpers/utils.py
+++ b/tangelo/helpers/utils.py
@@ -76,6 +76,7 @@ def deprecated(custom_message=""):
 all_backends = {"qulacs", "qiskit", "cirq", "braket", "projectq", "qdk", "pennylane", "sympy", "stim"}
 all_backends_simulator = {"qulacs", "qiskit", "cirq", "qdk"}
 sv_backends_simulator = {"qulacs", "qiskit", "cirq"}
+cmeasure_backends_simulator = {"qulacs", "cirq"}
 symbolic_backends = {"sympy"}
 chem_backends = {"pyscf", "psi4"}
 clifford_backends_simulator = {"stim"}
@@ -90,6 +91,7 @@ installed_simulator = installed_backends & all_backends_simulator
 installed_sv_simulator = installed_backends & sv_backends_simulator
 installed_chem_backends = {p_id for p_id in chem_backends if is_package_installed(p_id)}
 installed_clifford_simulators = {p_id for p_id in clifford_backends_simulator if is_package_installed(p_id)}
+installed_cmeasure_simulators = {p_id for p_id in cmeasure_backends_simulator if is_package_installed(p_id)}
 
 # Check if qulacs installed (better performance for tests). If not, defaults to cirq (always installed with openfermion)
 default_simulator = "qulacs" if "qulacs" in installed_sv_simulator else "cirq"

--- a/tangelo/linq/__init__.py
+++ b/tangelo/linq/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from .gate import *
-from .circuit import Circuit, stack, remove_small_rotations, remove_redundant_gates, get_unitary_circuit_pieces
+from .circuit import Circuit, stack, remove_small_rotations, remove_redundant_gates, get_unitary_circuit_pieces, ClassicalControl
 from .translator import *
 from .simulator import get_backend
 from .target.backend import get_expectation_value_from_frequencies_oneterm

--- a/tangelo/linq/circuit.py
+++ b/tangelo/linq/circuit.py
@@ -58,7 +58,7 @@ class Circuit:
         self._n_qubit_gate_counts: Dict[int, int] = dict()
         self._variational_gates: List[Gate] = []
         self._probabilities: Dict[str, float] = dict()
-        self._cmeasure_control: Callable = cmeasure_control
+        self._cmeasure_control: Union[Callable, ClassicalControl, None] = cmeasure_control
         self._applied_gates: List[Gate] = []
 
         if gates:
@@ -414,6 +414,11 @@ class Circuit:
             return Circuit(self._cmeasure_control(measure), n_qubits=self.width)
         elif isinstance(self._cmeasure_control, ClassicalControl):
             return Circuit(self._cmeasure_control.return_circuit(measure), n_qubits=self.width)
+
+    def finalize_cmeasure_control(self):
+        """Call the finalize method in cmeasure_control"""
+        if isinstance(self._cmeasure_control, ClassicalControl):
+            self._cmeasure_control.finalize()
 
 
 def stack(*circuits):

--- a/tangelo/linq/circuit.py
+++ b/tangelo/linq/circuit.py
@@ -176,7 +176,7 @@ class Circuit:
         will have circuit.applied_gates = [Gate("H", 0), Gate("CMEASURE", 0, parameter="0"), Gate("X", 1)]  or
                   circuit.applied_gates = [Gate("H", 0), Gate("CMEASURE", 0, parameter="1")]
         """
-        return self._applied_gates if self.counts.get("CMEASURE", 0) else self._gates
+        return self._applied_gates if "CMEASURE" in self.counts else self._gates
 
     def draw(self):
         """Method to output a prettier version of the circuit for use in jupyter notebooks that uses cirq SVGCircuit"""
@@ -418,6 +418,8 @@ class Circuit:
             return Circuit(self._cmeasure_control(measure), n_qubits=self.width)
         elif isinstance(self._cmeasure_control, ClassicalControl):
             return Circuit(self._cmeasure_control.return_circuit(measure), n_qubits=self.width)
+        else:
+            raise TypeError(f"cmeasure_control must either be a function or an instance of {ClassicalControl}")
 
     def finalize_cmeasure_control(self):
         """Call the finalize method in cmeasure_control"""

--- a/tangelo/linq/circuit.py
+++ b/tangelo/linq/circuit.py
@@ -21,7 +21,7 @@ characteristics (width, size ...).
 import copy
 import inspect
 import abc
-from typing import List, Tuple, Iterator
+from typing import List, Tuple, Iterator, Union, Set, Dict, Callable
 
 import numpy as np
 from cirq.contrib.svg import SVGCircuit
@@ -51,14 +51,15 @@ class Circuit:
         """Initialize gate list and internal variables depending on user input."""
 
         self.name = name
-        self._gates = list()
-        self._qubits_simulated = n_qubits
-        self._qubit_indices = set() if not n_qubits else set(range(n_qubits))
-        self._gate_counts = dict()
-        self._n_qubit_gate_counts = dict()
-        self._variational_gates = []
-        self._probabilities = dict()
-        self._cmeasure_control = cmeasure_control
+        self._gates: List[Gate] = list()
+        self._qubits_simulated: Union[None, int] = n_qubits
+        self._qubit_indices: Set[int] = set() if not n_qubits else set(range(n_qubits))
+        self._gate_counts: Dict[str, int] = dict()
+        self._n_qubit_gate_counts: Dict[int, int] = dict()
+        self._variational_gates: List[Gate] = []
+        self._probabilities: Dict[str, float] = dict()
+        self._cmeasure_control: Callable = cmeasure_control
+        self._applied_gates: List[Gate] = []
 
         if gates:
             _ = [self.add_gate(g) for g in gates]
@@ -164,6 +165,14 @@ class Circuit:
             return {"": 1}
         else:
             return self._probabilities
+
+    @property
+    def applied_gates(self):
+        """Returns the list of gates applied during the latest simulation of the circuit"""
+        if self.counts.get("CMEASURE", 0):
+            return self._applied_gates
+        else:
+            return self._gates
 
     def draw(self):
         """Method to output a prettier version of the circuit for use in jupyter notebooks that uses cirq SVGCircuit"""

--- a/tangelo/linq/target/backend.py
+++ b/tangelo/linq/target/backend.py
@@ -289,16 +289,20 @@ class Backend(abc.ABC):
         # For mid-circuit measurements post-process the result
         if save_mid_circuit_meas:
             # TODO: refactor to break a circular import. May involve by relocating get_xxx_oneterm functions
-            from tangelo.toolboxes.post_processing.post_selection import split_frequency_dict
+            from tangelo.toolboxes.post_processing.post_selection import split_frequency_dict, split_frequency_dict_for_last_n_digits
 
             (all_frequencies, statevector) = self.simulate_circuit(source_circuit,
                                                                    return_statevector=return_statevector,
                                                                    initial_statevector=initial_statevector,
                                                                    desired_meas_result=desired_meas_result,
                                                                    save_mid_circuit_meas=save_mid_circuit_meas)
-            self.mid_circuit_meas_freqs, frequencies = split_frequency_dict(all_frequencies,
-                                                                            list(range(n_meas)),
-                                                                            desired_measurement=desired_meas_result)
+            if n_cmeas == 0:
+                self.mid_circuit_meas_freqs, frequencies = split_frequency_dict(all_frequencies,
+                                                                                list(range(n_meas)),
+                                                                                desired_measurement=desired_meas_result)
+            else:
+                frequencies, self.mid_circuit_meas_freqs = split_frequency_dict_for_last_n_digits(all_frequencies,
+                                                                                                  source_circuit.width)
             return (frequencies, statevector)
 
         return self.simulate_circuit(source_circuit,

--- a/tangelo/linq/target/backend.py
+++ b/tangelo/linq/target/backend.py
@@ -301,7 +301,7 @@ class Backend(abc.ABC):
                                                                                 list(range(n_meas)),
                                                                                 desired_measurement=desired_meas_result)
             else:
-                frequencies, self.mid_circuit_meas_freqs = split_frequency_dict_for_last_n_digits(all_frequencies,
+                self.mid_circuit_meas_freqs, frequencies = split_frequency_dict_for_last_n_digits(all_frequencies,
                                                                                                   source_circuit.width)
             return (frequencies, statevector)
 
@@ -706,7 +706,7 @@ class Backend(abc.ABC):
             statevector (array): The statevector for which the collapse to the desired qubit value is performed.
             qubit (int): The index of the qubit to collapse to the classical result.
             result (string): "0" or "1".
-            ignore_zero_prob (bool): Default False, If True, a vector of zeros could be returned if probability is zero
+            ignore_zero_prob (bool): If True, a vector of zeros is returned if the probability is zero. Default value set to False.
 
         Returns:
             array: the collapsed and renormalized statevector

--- a/tangelo/linq/target/backend.py
+++ b/tangelo/linq/target/backend.py
@@ -740,7 +740,6 @@ class Backend(abc.ABC):
             else:
                 return "0", new_sv, prob
 
-
     @staticmethod
     @abc.abstractmethod
     def backend_info() -> dict:

--- a/tangelo/linq/target/backend.py
+++ b/tangelo/linq/target/backend.py
@@ -710,10 +710,36 @@ class Backend(abc.ABC):
 
         Returns:
             array: the collapsed and renormalized statevector
-            float: the probability this occured
+            float: the probability this occurred.
         """
 
         return collapse_statevector_to_desired_measurement(statevector, qubit, result, self.backend_info()['statevector_order'], ignore_zero_prob)
+
+    def perform_measurement(self, statevector, qubit, desired_meas_result=None):
+        """Perform a measurement and return the new statevector and the probability that measurement occurred
+
+        Args:
+            statevector (array): The statevector to perform the measurement on.
+            qubit (int): The qubit to apply the measurement to
+            desired_meas_result (Union[int, None]): The desired measurement result, Default None
+
+        Returns:
+            str: The result of the measurement
+            array: The measured and renormalized statevector
+            float: The probability this measurement occurred
+        """
+
+        if desired_meas_result:
+            new_sv, prob = self.collapse_statevector_to_desired_measurement(statevector, qubit, int(desired_meas_result))
+            return desired_meas_result, new_sv, prob
+        else:
+            new_sv, prob = self.collapse_statevector_to_desired_measurement(statevector, qubit, 0, ignore_zero_prob=True)
+            if prob < np.random.random():
+                new_sv, prob = self.collapse_statevector_to_desired_measurement(statevector, qubit, 1, ignore_zero_prob=True)
+                return "1", new_sv, prob
+            else:
+                return "0", new_sv, prob
+
 
     @staticmethod
     @abc.abstractmethod

--- a/tangelo/linq/target/target_cirq.py
+++ b/tangelo/linq/target/target_cirq.py
@@ -160,6 +160,10 @@ class CirqSimulator(Backend):
                     isamples = self.cirq.sample_state_vector(self._current_state, indices, repetitions=1)
                     bitstr = measurements + "".join([str(int(q)) for q in isamples[0]])
                     samples[bitstr] = samples.get(bitstr, 0) + 1
+
+                # Call the finalize method of ClassicalControl, used to reset variables, perform computation etc.
+                source_circuit.finalize_cmeasure_control()
+
             if self.n_shots:
                 self.all_frequencies = {k: v / self.n_shots for k, v in samples.items()}
                 frequencies = {k[:]: v / self.n_shots for k, v in samples.items()}

--- a/tangelo/linq/target/target_cirq.py
+++ b/tangelo/linq/target/target_cirq.py
@@ -90,64 +90,78 @@ class CirqSimulator(Backend):
                 sv = np.zeros(2**source_circuit.width)
                 sv[0] = 1
             success_probability = 1.
-            measurements = ""
-            unitary_circuits, qubits, cmeasure_flags = get_unitary_circuit_pieces(source_circuit)
-            precirc = [Circuit()]*len(unitary_circuits)
-            while len(unitary_circuits) > 1:
-                circ = precirc[0]+unitary_circuits[0]
-                applied_gates += circ._gates + [Gate("MEASURE", qubits[0])]
-                if circ.size > 0:
-                    translated_circuit = translate_c(circ, "cirq", output_options={"save_measurements": True})
-                    job_sim = cirq_simulator.simulate(translated_circuit, initial_state=sv)
-                    if desired_meas_result:
-                        measure = dmeas[0]
-                        measurements += measure
-                        sv, cprob = self.collapse_statevector_to_desired_measurement(job_sim.final_state_vector, qubits[0], int(dmeas[0]))
-                        del dmeas[0]
-                    else:
-                        sv, cprob = self.collapse_statevector_to_desired_measurement(job_sim.final_state_vector, qubits[0], 0, ignore_zero_prob=True)
-                        if np.random.random(1) > cprob:
-                            sv, cprob = self.collapse_statevector_to_desired_measurement(job_sim.final_state_vector, qubits[0], 1)
-                            measure = "1"
-                        else:
-                            measure = "0"
-                        measurements += measure
-                    # If a CMEASURE has occured
-                    if cmeasure_flags[0] is not None:
-                        if isinstance(cmeasure_flags[0], str):
-                            newcirc = source_circuit.controlled_measurement_op(measure)
-                        elif isinstance(cmeasure_flags[0], dict):
-                            newcirc = Circuit(cmeasure_flags[0][measure], n_qubits=source_circuit.width)
-                        new_unitary_circuits, new_qubits, new_cmeasure_flags = get_unitary_circuit_pieces(newcirc)
-                    # No classical control
-                    else:
-                        new_unitary_circuits = [Circuit(n_qubits=source_circuit.width)]
-                        new_qubits = []
-                        new_cmeasure_flags = []
-                    del unitary_circuits[0]
-                    del qubits[0]
-                    del cmeasure_flags[0]
-                    del precirc[0]
-                    precirc[0] = new_unitary_circuits[-1] + precirc[0]
-
-                    if len(new_unitary_circuits) > 1:
-                        unitary_circuits = new_unitary_circuits[:-1] + unitary_circuits
-                        qubits = new_qubits + qubits
-                        cmeasure_flags = new_cmeasure_flags + cmeasure_flags
-                        precirc = [Circuit()]*len(qubits) + precirc
-                else:
-                    sv, cprob = self.collapse_statevector_to_desired_measurement(sv, qubits[0], int(desired_meas_result[0]))
-                success_probability *= cprob
-            source_circuit._probabilities[measurements] = success_probability
-            applied_gates += precirc[0]._gates + unitary_circuits[-1]._gates
-            source_circuit._applied_gates = applied_gates
-            translated_circuit = translate_c(precirc[0]+unitary_circuits[-1], "cirq", output_options={"save_measurements": True})
-            job_sim = cirq_simulator.simulate(translated_circuit, initial_state=sv)
-            self._current_state = job_sim.final_state_vector
-            frequencies = self._statevector_to_frequencies(self._current_state)
             self.all_frequencies = dict()
-            for meas, val in frequencies.items():
-                self.all_frequencies[measurements + meas] = val
+            samples = dict()
+            n_shots = self.n_shots if self.n_shots is not None else 1
+            n_qubits = source_circuit.width
+            indices = list(range(n_qubits))
+            for shot in range(n_shots):
+                measurements = ""
+                unitary_circuits, qubits, cmeasure_flags = get_unitary_circuit_pieces(source_circuit)
+                precirc = [Circuit()]*len(unitary_circuits)
+                while len(unitary_circuits) > 1:
+                    circ = precirc[0]+unitary_circuits[0]
+                    applied_gates += circ._gates + [Gate("MEASURE", qubits[0])]
+                    if circ.size > 0:
+                        translated_circuit = translate_c(circ, "cirq", output_options={"save_measurements": True})
+                        job_sim = cirq_simulator.simulate(translated_circuit, initial_state=sv)
+                        if desired_meas_result:
+                            measure = dmeas[0]
+                            measurements += measure
+                            sv, cprob = self.collapse_statevector_to_desired_measurement(job_sim.final_state_vector, qubits[0], int(dmeas[0]))
+                            del dmeas[0]
+                        else:
+                            sv, cprob = self.collapse_statevector_to_desired_measurement(job_sim.final_state_vector, qubits[0], 0, ignore_zero_prob=True)
+                            if np.random.random(1) > cprob:
+                                sv, cprob = self.collapse_statevector_to_desired_measurement(job_sim.final_state_vector, qubits[0], 1)
+                                measure = "1"
+                            else:
+                                measure = "0"
+                            measurements += measure
+                        # If a CMEASURE has occured
+                        if cmeasure_flags[0] is not None:
+                            if isinstance(cmeasure_flags[0], str):
+                                newcirc = source_circuit.controlled_measurement_op(measure)
+                            elif isinstance(cmeasure_flags[0], dict):
+                                newcirc = Circuit(cmeasure_flags[0][measure], n_qubits=source_circuit.width)
+                            new_unitary_circuits, new_qubits, new_cmeasure_flags = get_unitary_circuit_pieces(newcirc)
+                        # No classical control
+                        else:
+                            new_unitary_circuits = [Circuit(n_qubits=source_circuit.width)]
+                            new_qubits = []
+                            new_cmeasure_flags = []
+                        del unitary_circuits[0]
+                        del qubits[0]
+                        del cmeasure_flags[0]
+                        del precirc[0]
+                        precirc[0] = new_unitary_circuits[-1] + precirc[0]
+
+                        if len(new_unitary_circuits) > 1:
+                            unitary_circuits = new_unitary_circuits[:-1] + unitary_circuits
+                            qubits = new_qubits + qubits
+                            cmeasure_flags = new_cmeasure_flags + cmeasure_flags
+                            precirc = [Circuit()]*len(qubits) + precirc
+                    else:
+                        sv, cprob = self.collapse_statevector_to_desired_measurement(sv, qubits[0], int(desired_meas_result[0]))
+                    success_probability *= cprob
+                source_circuit._probabilities[measurements] = success_probability
+                applied_gates += precirc[0]._gates + unitary_circuits[-1]._gates
+                source_circuit._applied_gates = applied_gates
+                translated_circuit = translate_c(precirc[0]+unitary_circuits[-1], "cirq", output_options={"save_measurements": True})
+                job_sim = cirq_simulator.simulate(translated_circuit, initial_state=sv)
+                self._current_state = job_sim.final_state_vector
+                if self.n_shots is None:
+                    frequencies = self._statevector_to_frequencies(self._current_state)
+                    for meas, val in frequencies.items():
+                        self.all_frequencies[measurements + meas] = val
+                else:
+                    isamples = self.cirq.sample_state_vector(self._current_state, indices, repetitions=1)
+                    bitstr = measurements + "".join([str(int(q)) for q in isamples[0]])
+                    samples[bitstr] = samples.get(bitstr, 0) + 1
+            if self.n_shots:
+                self.all_frequencies = {k: v / self.n_shots for k, v in samples.items()}
+
+                frequencies = {k[-n_qubits:]: v / self.n_shots for k, v in samples.items()}
 
         # Calculate final density matrix and sample from that for noisy simulation or simulating mixed states
         elif (self._noise_model or source_circuit.is_mixed_state) and not save_mid_circuit_meas:

--- a/tangelo/linq/target/target_cirq.py
+++ b/tangelo/linq/target/target_cirq.py
@@ -73,7 +73,7 @@ class CirqSimulator(Backend):
         n_cmeas = source_circuit.counts.get("CMEASURE", 0)
 
         if self._noise_model and n_cmeas > 0:
-            raise RuntimeError(f"{self.__class__.__name__} does not currently support measurement-controlled"
+            raise NotImplementedError(f"{self.__class__.__name__} does not currently support measurement-controlled"
                                "gates with a noise model.")
 
         # Only DensityMatrixSimulator handles noise well, can use Simulator, but it is slower

--- a/tangelo/linq/target/target_cirq.py
+++ b/tangelo/linq/target/target_cirq.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from collections import Counter
-from copy import copy
 
 import numpy as np
 
@@ -114,7 +113,7 @@ class CirqSimulator(Backend):
                         job_sim = cirq_simulator.simulate(translated_circuit, initial_state=sv)
                         sv = job_sim.final_state_vector
 
-                    # Perform measurement. 
+                    # Perform measurement.
                     desired_meas = dmeas[0] if desired_meas_result else None
                     measure, sv, cprob = self.perform_measurement(sv, qubits[0], desired_meas)
                     measurements += measure

--- a/tangelo/linq/target/target_qdk.py
+++ b/tangelo/linq/target/target_qdk.py
@@ -63,6 +63,9 @@ class QDKSimulator(Backend):
         with open('tmp_circuit.qs', 'w+') as f_out:
             f_out.write(translated_circuit)
 
+        if source_circuit.counts.get("CMEASURE", 0):
+            raise RuntimeError(f"{self.__class__.__name__} does not currently support CMEASURE operations.")
+
         if desired_meas_result:
             warnings.warn("qdk uses statistics from n_shots instead of statistics on the number of successful desired_meas_result.")
 

--- a/tangelo/linq/target/target_qdk.py
+++ b/tangelo/linq/target/target_qdk.py
@@ -63,7 +63,7 @@ class QDKSimulator(Backend):
         with open('tmp_circuit.qs', 'w+') as f_out:
             f_out.write(translated_circuit)
 
-        if source_circuit.counts.get("CMEASURE", 0):
+        if "CMEASURE" in source_circuit.counts:
             raise RuntimeError(f"{self.__class__.__name__} does not currently support CMEASURE operations.")
 
         if desired_meas_result:

--- a/tangelo/linq/target/target_qdk.py
+++ b/tangelo/linq/target/target_qdk.py
@@ -59,12 +59,12 @@ class QDKSimulator(Backend):
             numpy.array: The statevector, if available for the target backend
                 and requested by the user (if not, set to None).
         """
+        if "CMEASURE" in source_circuit.counts:
+            raise NotImplementedError(f"{self.__class__.__name__} does not currently support CMEASURE operations.")
+
         translated_circuit = translate_c(source_circuit, "qdk", output_options={"save_measurements": save_mid_circuit_meas})
         with open('tmp_circuit.qs', 'w+') as f_out:
             f_out.write(translated_circuit)
-
-        if "CMEASURE" in source_circuit.counts:
-            raise NotImplementedError(f"{self.__class__.__name__} does not currently support CMEASURE operations.")
 
         if desired_meas_result:
             warnings.warn("qdk uses statistics from n_shots instead of statistics on the number of successful desired_meas_result.")

--- a/tangelo/linq/target/target_qdk.py
+++ b/tangelo/linq/target/target_qdk.py
@@ -64,7 +64,7 @@ class QDKSimulator(Backend):
             f_out.write(translated_circuit)
 
         if "CMEASURE" in source_circuit.counts:
-            raise RuntimeError(f"{self.__class__.__name__} does not currently support CMEASURE operations.")
+            raise NotImplementedError(f"{self.__class__.__name__} does not currently support CMEASURE operations.")
 
         if desired_meas_result:
             warnings.warn("qdk uses statistics from n_shots instead of statistics on the number of successful desired_meas_result.")

--- a/tangelo/linq/target/target_qiskit.py
+++ b/tangelo/linq/target/target_qiskit.py
@@ -73,7 +73,7 @@ class QiskitSimulator(Backend):
             return backend, translated_circuit
 
         n_meas = source_circuit.counts.get("MEASURE", 0)
-        if source_circuit.counts.get("CMEASURE", 0):
+        if "CMEASURE" in source_circuit.counts:
             raise RuntimeError(f"{self.__class__.__name__} does not currently support CMEASURE operations.")
 
         qiskit_noise_model = get_qiskit_noise_model(self._noise_model) if self._noise_model else None

--- a/tangelo/linq/target/target_qiskit.py
+++ b/tangelo/linq/target/target_qiskit.py
@@ -74,7 +74,7 @@ class QiskitSimulator(Backend):
 
         n_meas = source_circuit.counts.get("MEASURE", 0)
         if "CMEASURE" in source_circuit.counts:
-            raise RuntimeError(f"{self.__class__.__name__} does not currently support CMEASURE operations.")
+            raise NotImplementedError(f"{self.__class__.__name__} does not currently support CMEASURE operations.")
 
         qiskit_noise_model = get_qiskit_noise_model(self._noise_model) if self._noise_model else None
 

--- a/tangelo/linq/target/target_qiskit.py
+++ b/tangelo/linq/target/target_qiskit.py
@@ -96,7 +96,7 @@ class QiskitSimulator(Backend):
         if desired_meas_result is not None and not self._noise_model:
             # Split circuit into chunks between mid-circuit measurements. Simulate a chunk, collapse the statevector according
             # to the desired measurement and simulate the next chunk using this new statevector as input
-            unitary_circuits, qubits = get_unitary_circuit_pieces(source_circuit)
+            unitary_circuits, qubits, _ = get_unitary_circuit_pieces(source_circuit)
         else:
             translated_circuit = translate_c(source_circuit, "qiskit", output_options={"save_measurements": save_mid_circuit_meas})
 

--- a/tangelo/linq/target/target_qiskit.py
+++ b/tangelo/linq/target/target_qiskit.py
@@ -74,6 +74,9 @@ class QiskitSimulator(Backend):
             return backend, translated_circuit
 
         n_meas = source_circuit.counts.get("MEASURE", 0)
+        if source_circuit.counts.get("CMEASURE", 0):
+            raise RuntimeError(f"{self.__class__.__name__} does not currently support CMEASURE operations.")
+
         qiskit_noise_model = get_qiskit_noise_model(self._noise_model) if self._noise_model else None
 
         def load_statevector(translated_circuit, initial_statevector):

--- a/tangelo/linq/target/target_qiskit.py
+++ b/tangelo/linq/target/target_qiskit.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import math
-from collections import Counter
 
 import numpy as np
 

--- a/tangelo/linq/target/target_qulacs.py
+++ b/tangelo/linq/target/target_qulacs.py
@@ -185,7 +185,6 @@ class QulacsSimulator(Backend):
 
             if self.n_shots:
                 self.all_frequencies = {k: v / self.n_shots for k, v in samples.items()}
-                frequencies = {k: v / self.n_shots for k, v in samples.items()}
             return (self.all_frequencies, python_statevector) if return_statevector else (self.all_frequencies, None)
 
         # Deterministic circuit, run once and sample from statevector

--- a/tangelo/linq/target/target_qulacs.py
+++ b/tangelo/linq/target/target_qulacs.py
@@ -107,8 +107,8 @@ class QulacsSimulator(Backend):
                         state.load(sv)
                         translated_circuit.update_quantum_state(state)
                         sv = state.get_vector()
-                    
-                    # Perform measurement. 
+
+                    # Perform measurement.
                     desired_meas = dmeas[0] if desired_meas_result else None
                     measure, sv, cprob = self.perform_measurement(sv, qubits[0], desired_meas)
                     measurements += measure

--- a/tangelo/linq/target/target_qulacs.py
+++ b/tangelo/linq/target/target_qulacs.py
@@ -156,6 +156,10 @@ class QulacsSimulator(Backend):
                 else:
                     bitstr = self._int_to_binstr(state.sampling(1)[0], source_circuit.width)
                     samples[measurements+bitstr] = samples.get(measurements+bitstr, 0) + 1
+
+                # Call the finalize method of ClassicalControl, used to reset variables, perform computation etc.
+                source_circuit.finalize_cmeasure_control()
+
             if self.n_shots:
                 self.all_frequencies = {k: v / self.n_shots for k, v in samples.items()}
                 frequencies = {k: v / self.n_shots for k, v in samples.items()}

--- a/tangelo/linq/target/target_qulacs.py
+++ b/tangelo/linq/target/target_qulacs.py
@@ -101,52 +101,49 @@ class QulacsSimulator(Backend):
                 while len(unitary_circuits) > 1:
                     circ = precirc[0] + unitary_circuits[0]
                     applied_gates += circ._gates + [Gate("MEASURE", qubits[0])]
+
                     if circ.size > 0:
                         translated_circuit = translate_c(circ, "qulacs", output_options={"save_measurements": True})
                         state.load(sv)
                         translated_circuit.update_quantum_state(state)
-                        if desired_meas_result:
-                            measure = dmeas[0]
-                            measurements += measure
-                            sv, cprob = self.collapse_statevector_to_desired_measurement(state.get_vector(), qubits[0], int(dmeas[0]))
-                            del dmeas[0]
-                        else:
-                            sv, cprob = self.collapse_statevector_to_desired_measurement(state.get_vector(), qubits[0], 0, ignore_zero_prob=True)
-                            if np.random.random(1) > cprob:
-                                sv, cprob = self.collapse_statevector_to_desired_measurement(state.get_vector(), qubits[0], 1)
-                                measure = "1"
-                            else:
-                                measure = "0"
-                            measurements += measure
-                        # If a CMEASURE has occured
-                        if cmeasure_flags[0] is not None:
-                            if isinstance(cmeasure_flags[0], str):
-                                newcirc = source_circuit.controlled_measurement_op(measure)
-                            elif isinstance(cmeasure_flags[0], dict):
-                                newcirc = Circuit(cmeasure_flags[0][measure], n_qubits=source_circuit.width)
-                            new_unitary_circuits, new_qubits, new_cmeasure_flags = get_unitary_circuit_pieces(newcirc)
-                        # No classical control
-                        else:
-                            new_unitary_circuits = [Circuit(n_qubits=source_circuit.width)]
-                            new_qubits = []
-                            new_cmeasure_flags = []
-                        del unitary_circuits[0]
-                        del qubits[0]
-                        del cmeasure_flags[0]
-                        del precirc[0]
-                        precirc[0] = new_unitary_circuits[-1] + precirc[0]
-
-                        if len(new_unitary_circuits) > 1:
-                            unitary_circuits = new_unitary_circuits[:-1] + unitary_circuits
-                            qubits = new_qubits + qubits
-                            cmeasure_flags = new_cmeasure_flags + cmeasure_flags
-                            precirc = [Circuit()]*len(qubits) + precirc
-                    else:
-                        sv, cprob = self.collapse_statevector_to_desired_measurement(sv, qubits[0], int(desired_meas_result[0]))
+                        sv = state.get_vector()
+                    
+                    # Perform measurement. 
+                    desired_meas = dmeas[0] if desired_meas_result else None
+                    measure, sv, cprob = self.perform_measurement(sv, qubits[0], desired_meas)
+                    measurements += measure
                     success_probability *= cprob
+                    if desired_meas_result:
+                        del dmeas[0]
+
+                    # If a CMEASURE has occured
+                    if cmeasure_flags[0] is not None:
+                        if isinstance(cmeasure_flags[0], str):
+                            newcirc = source_circuit.controlled_measurement_op(measure)
+                        elif isinstance(cmeasure_flags[0], dict):
+                            newcirc = Circuit(cmeasure_flags[0][measure], n_qubits=source_circuit.width)
+                        new_unitary_circuits, new_qubits, new_cmeasure_flags = get_unitary_circuit_pieces(newcirc)
+                    # No classical control
+                    else:
+                        new_unitary_circuits = [Circuit(n_qubits=source_circuit.width)]
+                        new_qubits = []
+                        new_cmeasure_flags = []
+
+                    del unitary_circuits[0]
+                    del qubits[0]
+                    del cmeasure_flags[0]
+                    del precirc[0]
+                    precirc[0] = new_unitary_circuits[-1] + precirc[0]
+
+                    if len(new_unitary_circuits) > 1:
+                        unitary_circuits = new_unitary_circuits[:-1] + unitary_circuits
+                        qubits = new_qubits + qubits
+                        cmeasure_flags = new_cmeasure_flags + cmeasure_flags
+                        precirc = [Circuit()]*len(qubits) + precirc
+
                 source_circuit._probabilities[measurements] = success_probability
                 applied_gates += precirc[0]._gates + unitary_circuits[-1]._gates
-                source_circuit._applied_gates += [applied_gates]
+                source_circuit._applied_gates = applied_gates
                 translated_circuit = translate_c(precirc[0]+unitary_circuits[-1], "qulacs", output_options={"save_measurements": True})
                 state.load(sv)
                 translated_circuit.update_quantum_state(state)

--- a/tangelo/linq/target/target_qulacs.py
+++ b/tangelo/linq/target/target_qulacs.py
@@ -100,7 +100,7 @@ class QulacsSimulator(Backend):
         elif desired_meas_result is not None:
             if not self._noise_model:
                 success_probability = 1
-                unitary_circuits, qubits = get_unitary_circuit_pieces(source_circuit)
+                unitary_circuits, qubits, _ = get_unitary_circuit_pieces(source_circuit)
 
                 for i, circ in enumerate(unitary_circuits[:-1]):
                     if circ.size > 0:

--- a/tangelo/linq/target/target_stim.py
+++ b/tangelo/linq/target/target_stim.py
@@ -59,7 +59,7 @@ class StimSimulator(Backend):
         if desired_meas_result is not None:
             raise NotImplementedError("desired_meas_result not yet implemented with stim ")
         if "CMEASURE" in source_circuit.counts:
-            raise RuntimeError(f"{self.__class__.__name__} does not currently support CMEASURE operations.")
+            raise NotImplementedError(f"{self.__class__.__name__} does not currently support CMEASURE operations.")
 
         if self.n_shots or self._noise_model:
             translated_circuit = translate_c(source_circuit, "stim",

--- a/tangelo/linq/target/target_stim.py
+++ b/tangelo/linq/target/target_stim.py
@@ -58,7 +58,7 @@ class StimSimulator(Backend):
             raise NotImplementedError("initial_statevector not yet implemented with stim ")
         if desired_meas_result is not None:
             raise NotImplementedError("desired_meas_result not yet implemented with stim ")
-        if source_circuit.counts.get("CMEASURE", 0):
+        if "CMEASURE" in source_circuit.counts:
             raise RuntimeError(f"{self.__class__.__name__} does not currently support CMEASURE operations.")
 
         if self.n_shots or self._noise_model:

--- a/tangelo/linq/target/target_stim.py
+++ b/tangelo/linq/target/target_stim.py
@@ -58,6 +58,8 @@ class StimSimulator(Backend):
             raise NotImplementedError("initial_statevector not yet implemented with stim ")
         if desired_meas_result is not None:
             raise NotImplementedError("desired_meas_result not yet implemented with stim ")
+        if source_circuit.counts.get("CMEASURE", 0):
+            raise RuntimeError(f"{self.__class__.__name__} does not currently support CMEASURE operations.")
 
         if self.n_shots or self._noise_model:
             translated_circuit = translate_c(source_circuit, "stim",

--- a/tangelo/linq/target/target_sympy.py
+++ b/tangelo/linq/target/target_sympy.py
@@ -54,7 +54,7 @@ class SympySimulator(Backend):
             qubit_to_matrix, measure_all
 
         if "CMEASURE" in source_circuit.counts:
-            raise RuntimeError(f"{self.__class__.__name__} does not currently support CMEASURE operations.")
+            raise NotImplementedError(f"{self.__class__.__name__} does not currently support CMEASURE operations.")
 
         translated_circuit = translate_c(source_circuit, "sympy")
 

--- a/tangelo/linq/target/target_sympy.py
+++ b/tangelo/linq/target/target_sympy.py
@@ -53,7 +53,7 @@ class SympySimulator(Backend):
         from sympy.physics.quantum.qubit import Qubit, matrix_to_qubit, \
             qubit_to_matrix, measure_all
 
-        if source_circuit.counts.get("CMEASURE", 0):
+        if "CMEASURE" in source_circuit.counts:
             raise RuntimeError(f"{self.__class__.__name__} does not currently support CMEASURE operations.")
 
         translated_circuit = translate_c(source_circuit, "sympy")

--- a/tangelo/linq/target/target_sympy.py
+++ b/tangelo/linq/target/target_sympy.py
@@ -53,6 +53,9 @@ class SympySimulator(Backend):
         from sympy.physics.quantum.qubit import Qubit, matrix_to_qubit, \
             qubit_to_matrix, measure_all
 
+        if source_circuit.counts.get("CMEASURE", 0):
+            raise RuntimeError(f"{self.__class__.__name__} does not currently support CMEASURE operations.")
+
         translated_circuit = translate_c(source_circuit, "sympy")
 
         # Transform the initial_statevector if it is provided.

--- a/tangelo/linq/tests/test_circuits.py
+++ b/tangelo/linq/tests/test_circuits.py
@@ -367,11 +367,12 @@ class TestCircuits(unittest.TestCase):
                     Circuit([Gate("H", 0)], n_qubits=2),
                     Circuit(n_qubits=2)]
         measure_qs = [0, 1, 0, 1, 1]
-        split_circuits, qubits_to_measure = get_unitary_circuit_pieces(test_circuit)
+        split_circuits, qubits_to_measure, meas_flags = get_unitary_circuit_pieces(test_circuit)
 
         for i, circ in enumerate(circuits[:-1]):
             self.assertEqual(circ, split_circuits[i])
             self.assertEqual(measure_qs[i], qubits_to_measure[i])
+            self.assertEqual(meas_flags[i], None)
         self.assertEqual(circuits[-1], split_circuits[-1])
 
 

--- a/tangelo/linq/tests/test_simulator.py
+++ b/tangelo/linq/tests/test_simulator.py
@@ -21,7 +21,6 @@ import unittest
 import os
 import time
 from typing import List
-from copy import copy
 
 import numpy as np
 from openfermion import load_operator, get_sparse_operator
@@ -679,7 +678,7 @@ class TestSimulateMisc(unittest.TestCase):
         cmeas_circuit = Circuit([Gate("CMEASURE", 0, parameter={"0": [], "1": []})])
         for backend in (installed_simulator | installed_clifford_simulators) - installed_cmeasure_simulators:
             sim = get_backend(backend, n_shots=1)
-            self.assertRaises(RuntimeError, sim.simulate, cmeas_circuit)
+            self.assertRaises(NotImplementedError, sim.simulate, cmeas_circuit)
 
     def test_measurement_controlled_gates_function(self):
         """Test that the repeat until success circuit is properly performed."""
@@ -729,7 +728,7 @@ class TestSimulateMisc(unittest.TestCase):
                 def __init__(self, n_bits: int):
                     """Iterative QPE with n_bits"""
                     self.n_bits: int = n_bits
-                    self.bitplace: int = copy(self.n_bits)
+                    self.bitplace: int = n_bits
                     self.phase: float = 0
                     self.measurements: List[str] = [""]
                     self.energies: List[float] = [0.]
@@ -756,7 +755,7 @@ class TestSimulateMisc(unittest.TestCase):
                         return []
 
                 def finalize(self):
-                    self.bitplace = copy(self.n_bits)
+                    self.bitplace = self.n_bits
                     self.phase = 0
                     self.n_runs += 1
                     self.measurements += [""]

--- a/tangelo/linq/tests/test_simulator.py
+++ b/tangelo/linq/tests/test_simulator.py
@@ -655,7 +655,7 @@ class TestSimulateMisc(unittest.TestCase):
             assert_freq_dict_almost_equal(circuit.success_probabilities, {"0": 0.5, "1": 0.5}, 1.e-7)
 
             # Test that an initial state of |0> or |1> is utilized by the circuit.
-            # Test with initial state H and measure "1". H|0> = (|0>+|1>)/sqrt(2) 
+            # Test with initial state H and measure "1". H|0> = (|0>+|1>)/sqrt(2)
             circuit = Circuit([Gate("H", 0), Gate("CMEASURE", 0, parameter={"0": [], "1": [Gate("X", 0)]})])
             f, sv = sim.simulate(circuit, save_mid_circuit_meas=True, desired_meas_result="1",
                                  initial_statevector=[1, 0], return_statevector=True)
@@ -691,11 +691,10 @@ class TestSimulateMisc(unittest.TestCase):
             assert_freq_dict_almost_equal(f, {"11": 1}, 1.e-7)
             assert_freq_dict_almost_equal(circuit.success_probabilities, {"001": 0.125}, 1.e-7)
             self.assertTrue(applied_circuit == Circuit(circuit.applied_gates))
-    
 
             # Test that the correct ordering of probabilities is obtained when running without specifying the
             # desired measurement result.
-            sim.n_shots=1000
+            sim.n_shots = 1000
 
             circuit = Circuit([Gate("H", 0), Gate("CMEASURE", 0),  Gate("CNOT", 1, 0)], cmeasure_control=cfunc)
             f, _ = sim.simulate(circuit, save_mid_circuit_meas=True)

--- a/tangelo/linq/tests/test_simulator.py
+++ b/tangelo/linq/tests/test_simulator.py
@@ -714,7 +714,7 @@ class TestSimulateMisc(unittest.TestCase):
             sim = get_backend(backend, n_shots=2)
 
             # Unitary has eigenvalue (1/16+1/8+1/2)*pi with eigenvector |1> on qubit 1.
-            # Measurement will be 0011010 = 0/64+0/32+1/16+1/8+0/4+1/2+0 
+            # Measurement will be 0011010 = 0/64+0/32+1/16+1/8+0/4+1/2+0
             ugate = Gate("CPHASE", 1, control=0, parameter=np.pi/16+np.pi/8+np.pi/2)
 
             class IterativeQPE(ClassicalControl):

--- a/tangelo/linq/translator/translate_cirq.py
+++ b/tangelo/linq/translator/translate_cirq.py
@@ -58,6 +58,7 @@ def get_cirq_gates():
     GATE_CIRQ["SWAP"] = cirq.SWAP
     GATE_CIRQ["CSWAP"] = cirq.SWAP
     GATE_CIRQ["MEASURE"] = cirq.measure
+    GATE_CIRQ["CMEASURE"] = cirq.measure
     return GATE_CIRQ
 
 

--- a/tangelo/linq/translator/translate_qulacs.py
+++ b/tangelo/linq/translator/translate_qulacs.py
@@ -58,6 +58,7 @@ def get_qulacs_gates():
     GATE_QULACS["SWAP"] = qulacs.QuantumCircuit.add_SWAP_gate
     GATE_QULACS["CSWAP"] = qulacs.gate.SWAP
     GATE_QULACS["MEASURE"] = qulacs.gate.Measurement
+    GATE_QULACS["CMEASURE"] = qulacs.gate.Measurement
     return GATE_QULACS
 
 
@@ -130,7 +131,7 @@ def translate_c_to_qulacs(source_circuit, noise_model=None, save_measurements=Fa
             target_circuit.add_gate(mat_gate)
         elif gate.name in {"CNOT"}:
             (GATE_QULACS[gate.name])(target_circuit, gate.control[0], gate.target[0])
-        elif gate.name in {"MEASURE"}:
+        elif gate.name in {"MEASURE", "CMEASURE"}:
             m_gate = (GATE_QULACS[gate.name])(gate.target[0], measure_count)
             target_circuit.add_gate(m_gate)
             if save_measurements:

--- a/tangelo/toolboxes/post_processing/post_selection.py
+++ b/tangelo/toolboxes/post_processing/post_selection.py
@@ -137,30 +137,28 @@ def split_frequency_dict(frequencies, indices, desired_measurement=None):
     return midcirc_dict, marginal_dict
 
 
-def split_frequency_dict_for_last_n_digits(frequencies, n_to_keep):
+def split_frequency_dict_for_last_n_digits(frequencies, n):
     """Marginalize the frequencies dictionary over the last_n_digits.
     This splits the frequency dictionary into two frequency dictionaries
     and aggregates the corresponding frequencies.
-    If desired_measurement is provided, the marginalized frequencies are
-    post-selected for that outcome on the mid-circuit measurements.
 
     Args:
         frequencies (dict): The input frequency dictionary
-        last_n_to_keep (int): The last n digits of the bitstring to store.
+        n (int): The last n digits of the bitstring to store
 
     Returns:
-        dict: The frequencies for the last n digits
         dict: The marginal frequencies for remaining indices (different bitstring lengths in general)
+        dict: The frequencies for the last n bits
     """
 
-    freq_dict = dict()
-    other_freq_dict = dict()
+    freqs1 = dict()
+    freqs2 = dict()
 
     for measure, count in frequencies.items():
         n_measure = len(measure)
-        measfreq = "".join([measure[i] for i in range(n_measure-n_to_keep, n_measure)])
-        measother = "".join([measure[i] for i in range(n_measure-n_to_keep)])
-        freq_dict[measfreq] = freq_dict.get(measfreq, 0.) + count
-        other_freq_dict[measother] = other_freq_dict.get(measother, 0.) + count
 
-    return freq_dict, other_freq_dict
+        meas_other, meas_last_n = measure[:n_measure-n], measure[n_measure-n:]
+        freqs1[meas_other] = freqs1.get(meas_other, 0.) + count
+        freqs2[meas_last_n] = freqs2.get(meas_last_n, 0.) + count
+
+    return freqs1, freqs2

--- a/tangelo/toolboxes/post_processing/post_selection.py
+++ b/tangelo/toolboxes/post_processing/post_selection.py
@@ -135,3 +135,31 @@ def split_frequency_dict(frequencies, indices, desired_measurement=None):
         marginal_dict = post_select(frequencies, expected_outcomes)
 
     return midcirc_dict, marginal_dict
+
+def split_frequency_dict_for_last_n_digits(frequencies, n_to_keep):
+    """Marginalize the frequencies dictionary over the last_n_digits.
+    This splits the frequency dictionary into two frequency dictionaries
+    and aggregates the corresponding frequencies.
+    If desired_measurement is provided, the marginalized frequencies are
+    post-selected for that outcome on the mid-circuit measurements.
+
+    Args:
+        frequencies (dict): The input frequency dictionary
+        last_n_to_keep (int): The last n digits of the bitstring to store in 
+
+    Returns:
+        dict: The frequencies for the last n digits
+        dict: The marginal frequencies for remaining indices (different bitstring lengths in general)
+    """
+
+    freq_dict = dict()
+    other_freq_dict = dict()
+
+    for measure, count in frequencies.items():
+        n_measure = len(measure)
+        measfreq = "".join([measure[i] for i in range(n_measure-n_to_keep, n_measure)])
+        measother = "".join([measure[i] for i in range(n_measure-n_to_keep)])
+        freq_dict[measfreq] = freq_dict.get(measfreq, 0.) + count
+        other_freq_dict[measother] = other_freq_dict.get(measother, 0.) + count
+
+    return freq_dict, other_freq_dict

--- a/tangelo/toolboxes/post_processing/post_selection.py
+++ b/tangelo/toolboxes/post_processing/post_selection.py
@@ -136,6 +136,7 @@ def split_frequency_dict(frequencies, indices, desired_measurement=None):
 
     return midcirc_dict, marginal_dict
 
+
 def split_frequency_dict_for_last_n_digits(frequencies, n_to_keep):
     """Marginalize the frequencies dictionary over the last_n_digits.
     This splits the frequency dictionary into two frequency dictionaries
@@ -145,7 +146,7 @@ def split_frequency_dict_for_last_n_digits(frequencies, n_to_keep):
 
     Args:
         frequencies (dict): The input frequency dictionary
-        last_n_to_keep (int): The last n digits of the bitstring to store in 
+        last_n_to_keep (int): The last n digits of the bitstring to store.
 
     Returns:
         dict: The frequencies for the last n digits


### PR DESCRIPTION
The initial version of measurement controlled operations.
Users introduce a "CMEASURE" Gate
Three choices
1) Dictionary for parameter, i.e. `Gate("CMEASURE", target, parameter= {"0": List[Gate], "1": List[Gate]})`
2) Function in the parameter, i.e. `Gate("CMEASURE", target, parameter=function(measurement))`
3) Subclass of ClassicalControl instantiated when initializing the Circuit, i.e. circuit = Circuit(List[Gate], cmeasure_control=Class)

The last is by far the most flexible as can be seen for iterative phase estimation in `test_simulator.py`.