### PR TITLE
Bug Fix: n_shots parameter was ignored in get_expectation_value

### DIFF
--- a/tangelo/linq/target/backend.py
+++ b/tangelo/linq/target/backend.py
@@ -337,7 +337,7 @@ class Backend(abc.ABC):
 
         # If the underlying operator is hermitian, expectation value is real and can be computed right away
         if are_coefficients_real:
-            if self._noise_model or not self.statevector_available \
+            if self._noise_model or not self.statevector_available or self.n_shots is not None \
                     or (state_prep_circuit.is_mixed_state and self.n_shots is not None) or state_prep_circuit.size == 0:
                 return self._get_expectation_value_from_frequencies(qubit_operator,
                                                                     state_prep_circuit,

--- a/tangelo/linq/tests/test_simulator.py
+++ b/tangelo/linq/tests/test_simulator.py
@@ -368,6 +368,37 @@ class TestSimulateStatevector(unittest.TestCase):
         if test_fail:
             assert False
 
+    def test_get_exp_value_h2_with_n_shots(self):
+        """ Get expectation value of large circuits and qubit Hamiltonians corresponding to molecules.
+            Molecule: H2 sto-3g = [("H", (0., 0., 0.)), ("H", (0., 0., 0.741377))] with increasing shots
+            obtains better accuracy but never the exact result.
+        """
+        qubit_operator = load_operator("mol_H2_qubitham.data", data_directory=path_data, plain_text=True)
+
+        with open(f"{path_data}/H2_UCCSD.qasm", "r") as circ_handle:
+            openqasm_circ = circ_handle.read()
+
+        abs_circ = translate_c(openqasm_circ, "tangelo", source="openqasm")
+        expected = -1.1372704
+        test_fail = False
+
+        for n_shots in [10**2, 10**4, 10**6]:
+            for b in installed_sv_simulator:
+                sim = get_backend(target=b, n_shots=n_shots)
+                tstart = time.time()
+                energy = sim.get_expectation_value(qubit_operator, abs_circ)
+                tstop = time.time()
+                print(f"H2 get exp value with {b:10s} with n_shots={n_shots} returned {energy:.7f} \t Elapsed: {tstop - tstart:.3f} s.")
+
+                try:
+                    self.assertNotAlmostEqual(energy, expected, delta=1.e-7)
+                    self.assertAlmostEqual(energy, expected, delta=10/np.sqrt(n_shots))
+                except AssertionError:
+                    test_fail = True
+                    print(f"{self._testMethodName} : Assertion failed {b} (result = {energy:.7f}, expected = {expected})")
+            if test_fail:
+                assert False
+
     def test_get_exp_value_from_initial_statevector_h2(self):
         """ Get expectation value of large circuits and qubit Hamiltonians corresponding to molecules.
             Molecule: H2 sto-3g = [("H", (0., 0., 0.)), ("H", (0., 0., 0.741377))]

--- a/tangelo/linq/tests/test_simulator.py
+++ b/tangelo/linq/tests/test_simulator.py
@@ -391,7 +391,7 @@ class TestSimulateStatevector(unittest.TestCase):
                 print(f"H2 get exp value with {b:10s} with n_shots={n_shots} returned {energy:.7f} \t Elapsed: {tstop - tstart:.3f} s.")
 
                 try:
-                    self.assertNotAlmostEqual(energy, expected, delta=1.e-7)
+                    self.assertNotAlmostEqual(energy, expected, delta=1.e-6)
                     self.assertAlmostEqual(energy, expected, delta=10/np.sqrt(n_shots))
                 except AssertionError:
                     test_fail = True


### PR DESCRIPTION
n_shots was ignored in get_expectation_value if not paired with mixed state.