### PR TITLE
Classical solver uses mo_coeff from SecondQuantizedMolecule

### DIFF
--- a/tangelo/algorithms/classical/tests/test_fci_solver.py
+++ b/tangelo/algorithms/classical/tests/test_fci_solver.py
@@ -15,9 +15,11 @@
 import unittest
 
 import numpy as np
+from openfermion import get_sparse_operator
 
 from tangelo import SecondQuantizedMolecule
 from tangelo.algorithms import FCISolver
+from tangelo.toolboxes.qubit_mappings.mapping_transform import fermion_to_qubit_mapping
 from tangelo.molecule_library import mol_H2_321g, mol_Be_321g, mol_H4_cation_sto3g, mol_H4_sto3g, xyz_H4
 
 
@@ -98,8 +100,6 @@ class FCISolverTest(unittest.TestCase):
         # Modify orbitals
         mol.mo_coeff = unitary_mat.T@mol.mo_coeff
 
-        from openfermion import get_sparse_operator
-        from tangelo.toolboxes.qubit_mappings.mapping_transform import fermion_to_qubit_mapping
         op = get_sparse_operator(fermion_to_qubit_mapping(mol.fermionic_hamiltonian, "JW")).toarray()
         energy_op = np.linalg.eigh(op)[0][0]
 

--- a/tangelo/algorithms/classical/tests/test_fci_solver.py
+++ b/tangelo/algorithms/classical/tests/test_fci_solver.py
@@ -14,8 +14,11 @@
 
 import unittest
 
+import numpy as np
+
+from tangelo import SecondQuantizedMolecule
 from tangelo.algorithms import FCISolver
-from tangelo.molecule_library import mol_H2_321g, mol_Be_321g, mol_H4_cation_sto3g, mol_H4_sto3g
+from tangelo.molecule_library import mol_H2_321g, mol_Be_321g, mol_H4_cation_sto3g, mol_H4_sto3g, xyz_H4
 
 
 class FCISolverTest(unittest.TestCase):
@@ -80,6 +83,30 @@ class FCISolverTest(unittest.TestCase):
 
         one_rdm, two_rdm = solver.get_rdm()
         self.assertAlmostEqual(energy, mol_H4_sto3g_freeze3.energy_from_rdms(one_rdm, two_rdm), places=5)
+
+    def test_fci_H4_modified_mo_coeff(self):
+        """ Test FCISolver against result from reference implementation with interior frozen orbitals by manually defining
+        a swap operation.
+        """
+
+        mol = SecondQuantizedMolecule(xyz_H4, frozen_orbitals=[1, 3, 4])
+
+        unitary_mat = np.array([[ 0.99799630, -0.05866044,  0.02358562,  0.00246221],
+                                [ 0.05673690,  0.99556613,  0.07416274,  0.01135272],
+                                [-0.02767097, -0.07212301,  0.99605136, -0.04375241],
+                                [-0.00431649, -0.01432819,  0.04272342,  0.99897486]])
+        # Modify orbitals
+        mol.mo_coeff = unitary_mat.T@mol.mo_coeff
+
+        from openfermion import get_sparse_operator
+        from tangelo.toolboxes.qubit_mappings.mapping_transform import fermion_to_qubit_mapping
+        op = get_sparse_operator(fermion_to_qubit_mapping(mol.fermionic_hamiltonian, "JW")).toarray()
+        energy_op = np.linalg.eigh(op)[0][0]
+
+        solver = FCISolver(mol)
+        energy = solver.simulate()
+        self.assertAlmostEqual(energy, -1.8057990, places=5)
+        self.assertAlmostEqual(energy_op, -1.8057990, places=5)
 
 
 if __name__ == "__main__":

--- a/tangelo/toolboxes/molecular_computation/integral_solver_pyscf.py
+++ b/tangelo/toolboxes/molecular_computation/integral_solver_pyscf.py
@@ -171,6 +171,13 @@ class IntegralSolverPySCF(IntegralSolver):
 
         self.mo_coeff = sqmol.mean_field.mo_coeff
 
+    def modify_solver_mo_coeff(self, sqmol):
+        """Change the molecular coefficients in the SecondQuantizedMolecule mean_field object using self.mo_coeff
+        Args:
+            sqmol (SecondQuantizedMolecule): The SecondQuantizedMolecule object with mo_coeff
+        """
+        sqmol.mean_field.mo_coeff = self.mo_coeff
+
     def get_integrals(self, sqmol, mo_coeff=None):
         r"""Computes core constant, one_body, and two-body integrals for all orbitals
 

--- a/tangelo/toolboxes/molecular_computation/molecule.py
+++ b/tangelo/toolboxes/molecular_computation/molecule.py
@@ -304,6 +304,8 @@ class SecondQuantizedMolecule(Molecule):
             f"The new molecular coefficients matrix has a {new_mo_coeff.shape}"\
             f" shape: expected shape is {self.solver.mo_coeff.shape}."
         self.solver.mo_coeff = new_mo_coeff
+        if hasattr(self, "mean_field"):
+            self.mean_field.mo_coeff = new_mo_coeff
 
     def _get_fermionic_hamiltonian(self, mo_coeff=None):
         """This method returns the fermionic hamiltonian. It written to take

--- a/tangelo/toolboxes/molecular_computation/molecule.py
+++ b/tangelo/toolboxes/molecular_computation/molecule.py
@@ -304,8 +304,8 @@ class SecondQuantizedMolecule(Molecule):
             f"The new molecular coefficients matrix has a {new_mo_coeff.shape}"\
             f" shape: expected shape is {self.solver.mo_coeff.shape}."
         self.solver.mo_coeff = new_mo_coeff
-        if hasattr(self, "mean_field"):
-            self.mean_field.mo_coeff = new_mo_coeff
+        if hasattr(self.solver, "modify_solver_mo_coeff"):
+            self.solver.modify_solver_mo_coeff(self)
 
     def _get_fermionic_hamiltonian(self, mo_coeff=None):
         """This method returns the fermionic hamiltonian. It written to take


### PR DESCRIPTION
Classical solvers used the molecular coefficients from the initial Hartree-Fock calculation and not the molecular coefficients stored in the SecondQuantizedMolecule object. This fixes it for PySCF and Psi4.