### PR TITLE
Function that returns the qubits used for Truncated Taylor Series

### DIFF
--- a/tangelo/toolboxes/circuits/lcu.py
+++ b/tangelo/toolboxes/circuits/lcu.py
@@ -67,6 +67,20 @@ def get_truncated_taylor_series(qu_op: QubitOperator, kmax: int, t: float, contr
     return amplified_lcu_circuit * rsteps
 
 
+def get_truncated_taylor_series_qubits(qu_op: QubitOperator, kmax: int):
+    """Return the list of qubits used in the Truncated Taylor series circuit
+    Args:
+        qu_op (QubitOperator) :: The qubit operator to obtain the Uprep circuit for
+        kmax (int): the order of the truncated Taylor series
+        t (float): The evolution time
+    Returns:
+        List[int]: The list of qubit indices used
+    """
+    n_qubits = math.ceil(math.log2(len(qu_op.terms)))
+    qu_op_size = count_qubits(qu_op)
+    return list(range(qu_op_size + kmax+1 + kmax*n_qubits))
+
+
 def Uprepkl(qu_op: QubitOperator, kmax: int, t: float) -> Tuple[Circuit, List[QubitOperator], int]:
     """Generate Uprep circuit using qubit encoding defined in arXiv:1412.4687
     Args:

--- a/tangelo/toolboxes/circuits/lcu.py
+++ b/tangelo/toolboxes/circuits/lcu.py
@@ -72,7 +72,6 @@ def get_truncated_taylor_series_qubits(qu_op: QubitOperator, kmax: int):
     Args:
         qu_op (QubitOperator) :: The qubit operator to obtain the Uprep circuit for
         kmax (int): the order of the truncated Taylor series
-        t (float): The evolution time
     Returns:
         List[int]: The list of qubit indices used
     """

--- a/tangelo/toolboxes/circuits/tests/test_lcu.py
+++ b/tangelo/toolboxes/circuits/tests/test_lcu.py
@@ -26,7 +26,7 @@ from tangelo.toolboxes.operators.operators import QubitOperator
 from tangelo.toolboxes.qubit_mappings.mapping_transform import fermion_to_qubit_mapping
 from tangelo.toolboxes.ansatz_generator.ansatz_utils import get_qft_circuit
 from tangelo.molecule_library import mol_H2_sto3g
-from tangelo.toolboxes.circuits.lcu import get_oaa_lcu_circuit, get_truncated_taylor_series
+from tangelo.toolboxes.circuits.lcu import get_oaa_lcu_circuit, get_truncated_taylor_series, get_truncated_taylor_series_qubits
 
 # Test for both "cirq" and if available "qulacs". These have different orderings.
 # qiskit is not currently supported because does not have multi controlled general gates.
@@ -39,7 +39,7 @@ sim_cirq = get_backend("cirq")
 class LCUTest(unittest.TestCase):
 
     def test_get_truncated_taylor_series(self):
-        """Test time-evolution of truncated Taylor series for different orders and times"""
+        """Test time-evolution of truncated Taylor series for different orders and times along with qubit indices function"""
 
         qu_op = fermion_to_qubit_mapping(mol_H2_sto3g.fermionic_hamiltonian, "scbk", mol_H2_sto3g.n_active_sos, mol_H2_sto3g.n_active_electrons,
                                          True, 0)
@@ -64,6 +64,9 @@ class LCUTest(unittest.TestCase):
                 len_ancilla = 2**(k+k*n_qubits_qu_op+1)
                 v = v.reshape([4, len_ancilla])[:, 0] if statevector_order == "lsq_first" else v.reshape([len_ancilla, 4])[0, :]
                 self.assertAlmostEqual(1, np.abs(v.conj().dot(exact)), delta=3.e-1**k)
+
+                # Test that the qubits in the circuit are equal to the qubit indices returned from get_truncated_taylor_series_qubits
+                self.assertEqual(taylor_circuit._qubit_indices, set(get_truncated_taylor_series_qubits(qu_op, k)))
 
         # Raise ValueError if Taylor series order is less than 1 or greater than 4
         # or imaginary coefficients in qubit operator


### PR DESCRIPTION
A simple function that pre-computes the qubits used when calling the `get_truncated_taylor_series` function. 