### PR TITLE
Convert name of Gate to uppercase when initializing

### DIFF
--- a/tangelo/linq/gate.py
+++ b/tangelo/linq/gate.py
@@ -82,6 +82,11 @@ class Gate(dict):
 
         check_qubit_indices(target, "target")
 
+        if not isinstance(name, str):
+            raise TypeError(f"The name of the gate must be a string but received {type(name)}")
+        else:
+            name = name.upper()
+
         if control is not None:
             if name[0] != "C":
                 raise ValueError(f"Gate {name} was given control={control} but does not support controls. Try C{name}")

--- a/tangelo/linq/tests/test_gates.py
+++ b/tangelo/linq/tests/test_gates.py
@@ -24,6 +24,10 @@ class TestGates(unittest.TestCase):
         A test class to check that the circuit class is working properly, and processing the information
         of the gate objects it holds as expected.
     """
+    def test_name(self):
+        """ Test that name is a string and that it converts it to uppercase when initializing"""
+        self.assertRaises(TypeError, Gate, 1, 1)
+        self.assertEqual(Gate("H", 1), Gate("h", 1))
 
     def test_some_gates(self):
         """ Test that some basic gates can be invoked with a few different parameters, and that this information


### PR DESCRIPTION
1. Checks that name is a string and raises a TypeError otherwise
2. Converts the string to uppercase to match our convention.