### PR TITLE
Small fixes for ILC

### DIFF
--- a/tangelo/algorithms/variational/iqcc_ilc_solver.py
+++ b/tangelo/algorithms/variational/iqcc_ilc_solver.py
@@ -256,21 +256,21 @@ class iQCC_ILC_solver:
         if self.compress_qubit_ham:
             self.ilc_ansatz.qubit_ham.frobenius_norm_compression(self.compress_eps, n_qubits)
 
-        # set dis, acs, and var_params to none to rebuild the dis & acs and initialize new parameters
-        self.ilc_ansatz.dis = None
-        self.ilc_ansatz.acs = None
-        self.ilc_ansatz.var_params = None
-        self.ilc_ansatz.build_circuit()
-
-        self.vqe_solver.qubit_hamiltonian = self.ilc_ansatz.qubit_ham
-        self.vqe_solver.initial_var_params = self.ilc_ansatz.var_params
-
         if self.iteration == self.max_ilc_iter:
             self.terminate_ilc = True
             self.final_optimal_qmf_params = optimal_qmf_var_params
             self.final_optimal_ilc_params = optimal_ilc_var_params
             if self.verbose:
                 print(f"Terminating the ILC-VQE solver after {self.max_ilc_iter} iterations.")
+        else:
+            # set dis, acs, and var_params to none to rebuild the dis & acs and initialize new parameters
+            self.ilc_ansatz.dis = None
+            self.ilc_ansatz.acs = None
+            self.ilc_ansatz.var_params = None
+            self.ilc_ansatz.build_circuit()
+
+            self.vqe_solver.qubit_hamiltonian = self.ilc_ansatz.qubit_ham
+            self.vqe_solver.initial_var_params = self.ilc_ansatz.var_params
 
     def _update_qcc_solver(self, e_iqcc_ilc):
         """Updates after the final QCC energy evaluation with the final ILC dressed

--- a/tangelo/algorithms/variational/iqcc_ilc_solver.py
+++ b/tangelo/algorithms/variational/iqcc_ilc_solver.py
@@ -263,7 +263,7 @@ class iQCC_ILC_solver:
             if self.verbose:
                 print(f"Terminating the ILC-VQE solver after {self.max_ilc_iter} iterations.")
         else:
-            # set dis, acs, and var_params to none to rebuild the dis & acs and initialize new parameters
+            # Set dis, acs, and var_params to None to rebuild the dis & acs and initialize new parameters
             self.ilc_ansatz.dis = None
             self.ilc_ansatz.acs = None
             self.ilc_ansatz.var_params = None

--- a/tangelo/toolboxes/ansatz_generator/_qubit_ilc.py
+++ b/tangelo/toolboxes/ansatz_generator/_qubit_ilc.py
@@ -220,6 +220,8 @@ def get_ilc_params_by_diag(qubit_ham, ilc_gens, qmf_var_params, return_energy=Fa
     Args:
         qubit_ham (QubitOperator): the qubit Hamiltonian of the system.
         ilc_gens (list of QubitOperator): the anticommuting set of ILC Pauli words.
+        qmf_var_params (array): The QMF variational parameters
+        return_energy (bool): Return the energy from the ILC diagonalization. Default False.
 
     Returns:
         list of float: the ILC parameters corresponding to the ACS of ILC generators
@@ -289,7 +291,7 @@ def build_ilc_qubit_op_list(acs_gens, ilc_params):
     """
 
     n_amps = len(ilc_params)
-    ilc_op_list = [-.5 * ilc_params[i] * acs_gens[i] for i in range(0, n_amps-1)]
+    ilc_op_list = [-.5 * ilc_params[i] * acs_gens[i] for i in range(n_amps-1)]
     ilc_op_list += [-ilc_params[n_amps-1] * acs_gens[n_amps-1]]
     ilc_op_list += [-.5 * ilc_params[i] * acs_gens[i] for i in range(n_amps-2, -1, -1)]
     return ilc_op_list

--- a/tangelo/toolboxes/ansatz_generator/_qubit_ilc.py
+++ b/tangelo/toolboxes/ansatz_generator/_qubit_ilc.py
@@ -257,8 +257,8 @@ def get_ilc_params_by_diag(qubit_ham, ilc_gens, qmf_var_params):
 
     # Compute the ILC parameters using the ground state coefficients
     gs_coefs = subspace_coefs[:, 0]
-    if gs_coefs[0].real > 0.:
-        gs_coefs *= -1.
+    if gs_coefs[0].real < 0.:
+        gs_coefs = -gs_coefs
     denom_sum, ilc_var_params = 0., []
     for i in range(2):
         denom_sum += abs(gs_coefs[i])**2
@@ -346,7 +346,7 @@ def build_ilc_qubit_op_list(acs_gens, ilc_params):
 
     n_amps = len(ilc_params)
     ilc_op_list = [-.5 * ilc_params[i] * acs_gens[i] for i in range(n_amps-1, 0, -1)]
-    ilc_op_list += [ilc_params[0] * acs_gens[0]]
+    ilc_op_list += [-ilc_params[0] * acs_gens[0]]
     ilc_op_list += [-.5 * ilc_params[i] * acs_gens[i] for i in range(1, n_amps)]
     return ilc_op_list
 

--- a/tangelo/toolboxes/ansatz_generator/_qubit_ilc.py
+++ b/tangelo/toolboxes/ansatz_generator/_qubit_ilc.py
@@ -272,6 +272,63 @@ def get_ilc_params_by_diag(qubit_ham, ilc_gens, qmf_var_params):
     return ilc_var_params
 
 
+def get_ilc_params_by_diag_with_energy(qubit_ham, ilc_gens, qmf_var_params):
+    """Driver function that solves the generalized eigenvalue problem Hc = ESc required
+    to obtain the ground state coefficients (ILC parameters). These are subsequently recast
+    according to Appendix C of Ref. 1 in a form that is suitable for constructing ILC circuits.
+
+    This version generates the parameters assuming the exact circuit expansion of Eq. 17 of
+    https://arxiv.org/pdf/2002.05701.pdf
+
+    Args:
+        qubit_ham (QubitOperator): the qubit Hamiltonian of the system.
+        ilc_gens (list of QubitOperator): the anticommuting set of ILC Pauli words.
+
+    Returns:
+        list of float: the ILC parameters corresponding to the ACS of ILC generators
+    """
+
+    # Add the identity operator to the local copy of the ACS
+    ilc_gens.insert(0, QubitOperator.identity())
+    n_var_params = len(ilc_gens)
+    qubit_ham_mat = np.zeros((n_var_params, n_var_params), dtype=complex)
+    qubit_overlap_mat = np.zeros((n_var_params, n_var_params), dtype=complex)
+
+    # Construct the lower triangular matrices for the qubit Hamiltonian and overlap integrals
+    for i in range(n_var_params):
+        # H T_i|QMF> = H |psi_i>
+        h_psi_i = qubit_ham * ilc_gens[i]
+
+        # <QMF|T_i H T_i|QMF> = <psi_i| H | psi_i> = H_ii
+        qubit_ham_mat[i, i] = get_op_expval(ilc_gens[i] * h_psi_i, qmf_var_params)
+
+        # <QMF|T_i T_i|QMF> = <psi_i|psi_i> = 1
+        qubit_overlap_mat[i, i] = 1. + 0j
+
+        for j in range(i+1, n_var_params):
+            # <QMF|T_j H T_i|QMF> = <psi_j| H | psi_i> = H_ji
+            qubit_ham_mat[j, i] = get_op_expval(ilc_gens[j] * h_psi_i, qmf_var_params)
+
+            # <QMF|T_j T_i|QMF> = <psi_j|psi_i> --> exactly zero only for pure QMF states
+            qubit_overlap_mat[j, i] = get_op_expval(ilc_gens[j] * ilc_gens[i], qmf_var_params)
+            if i == 0:
+                qubit_ham_mat[j, i] *= 1j
+                qubit_overlap_mat[j, i] *= 1j
+
+    # Solve the generalized eigenvalue problem
+    energies, subspace_coefs = scipy.linalg.eigh(a=qubit_ham_mat, b=qubit_overlap_mat, lower=True, driver="gvd")
+
+    # Compute the ILC parameters using the ground state coefficients
+    gs_coefs = subspace_coefs[:, 0]
+    tau = np.arccos(gs_coefs[0])
+    ilc_var_params = []
+    for j, val in enumerate(gs_coefs[1:]):
+        ilc_var_params += [val/np.sin(tau)*tau]
+
+    del ilc_gens[0]
+    return ilc_var_params, energies[0]
+
+
 def build_ilc_qubit_op_list(acs_gens, ilc_params):
     """Returns a list of 2N - 1 ILC generators to facilitate generation of a circuit
     based on symmetric Trotter-Suzuki decomposition. The ILC generators are ordered
@@ -341,6 +398,40 @@ def ilc_op_dress(qubit_op, ilc_gens, ilc_params):
                   - .5j * sin_2tau * alphas[i] * commutator(qubit_op, ilc_gens[i])
         for j in range(i+1, n_amps):
             qop_dress += sin2_tau * alphas[i] * alphas[j] * (ilc_gens[i] * qubit_op * ilc_gens[j]
-                      + ilc_gens[j] * qubit_op * ilc_gens[i])
+                                                             + ilc_gens[j] * qubit_op * ilc_gens[i])
     qop_dress.compress()
+    return qop_dress
+
+
+def ilc_op_dress_exact(qubit_op, ilc_gens, ilc_params):
+    """Performs transformation of a qubit operator with the ACS of ILC generators and
+    parameters. For a set of N generators, each qubit operator transformation results
+    in quadratic (N * (N-1) / 2) growth of the number of its terms.
+
+    This version is taken from equation 17 of https://arxiv.org/pdf/2002.05701.pdf
+
+    Args:
+        qubit_op (QubitOperator): A qubit operator to be dressed.
+        ilc_gens (list of QubitOperator): The list of ILC Pauli word generators
+            selected from a user-specified number of characteristic ACS groups.
+        ilc_params (list or numpy array of float): The ILC variational parameters
+            arranged such that their ordering matches the ordering of ilc_gens.
+
+    Returns:
+        QubitOperator: Dressed qubit operator.
+    """
+
+    # first, recast the beta parameters into the set of coefficients {c_n}
+    tau = np.linalg.norm(ilc_params)
+    alphas = np.array(ilc_params)/tau
+
+    ctau2 = np.cos(tau)**2
+    s2tau = np.sin(2*tau)
+    stau2 = np.sin(tau)**2
+    qop_dress = ctau2*qubit_op
+    for i, ai in enumerate(alphas):
+        qop_dress += -1j/2*s2tau*ai*commutator(qubit_op, ilc_gens[i])
+        for j, aj in enumerate(alphas):
+            qop_dress += stau2*ai*aj*(ilc_gens[i] * qubit_op * ilc_gens[j])
+
     return qop_dress

--- a/tangelo/toolboxes/ansatz_generator/ilc.py
+++ b/tangelo/toolboxes/ansatz_generator/ilc.py
@@ -196,7 +196,7 @@ class ILC(Ansatz):
 
     def build_circuit(self, var_params=None):
         """Build and return the quantum circuit implementing the state preparation ansatz
-         (with currently specified initial_state and var_params). """
+         (with currently specified initial_state and var_params)."""
 
         # Build the DIS or specify a list of generators; updates the number of QCC parameters
         self._get_ilc_generators()

--- a/tangelo/toolboxes/ansatz_generator/tests/test_ilc.py
+++ b/tangelo/toolboxes/ansatz_generator/tests/test_ilc.py
@@ -175,12 +175,12 @@ class ILCTest(unittest.TestCase):
         qmf_var_params = [ 3.14159265e+00, -1.02576971e-11,  1.35522331e-11,  3.14159265e+00,
                            3.14159265e+00, -5.62116001e-11, -1.41419277e-11, -2.36789365e-11,
                           -5.53225030e-11, -3.56400157e-11, -2.61030058e-11, -3.55652002e-11]
-        ilc_var_params, energy = get_ilc_params_by_diag(qubit_hamiltonian, ilc_ansatz.acs, np.array(qmf_var_params), return_energy=True)
+        ilc_var_params, energy_diag = get_ilc_params_by_diag(qubit_hamiltonian, ilc_ansatz.acs, np.array(qmf_var_params), return_energy=True)
         var_params = qmf_var_params + ilc_var_params
         # Assert energy returned is as expected for given parameters
         ilc_ansatz.update_var_params(var_params)
         energy = sim.get_expectation_value(qubit_hamiltonian, ilc_ansatz.circuit)
-        self.assertAlmostEqual(energy, energy, delta=1e-5)
+        self.assertAlmostEqual(energy_diag, energy, delta=1e-5)
 
 
 if __name__ == "__main__":

--- a/tangelo/toolboxes/ansatz_generator/tests/test_ilc.py
+++ b/tangelo/toolboxes/ansatz_generator/tests/test_ilc.py
@@ -21,7 +21,7 @@ import numpy as np
 
 from tangelo.linq import get_backend
 from tangelo.toolboxes.ansatz_generator.ilc import ILC
-from tangelo.toolboxes.ansatz_generator._qubit_ilc import gauss_elim_over_gf2
+from tangelo.toolboxes.ansatz_generator._qubit_ilc import gauss_elim_over_gf2, get_ilc_params_by_diag
 from tangelo.toolboxes.operators.operators import QubitOperator
 from tangelo.molecule_library import mol_H2_sto3g, mol_H4_cation_sto3g
 
@@ -148,7 +148,7 @@ class ILCTest(unittest.TestCase):
 
         # The QMF and ILC parameters can both be specified; determined automatically otherwise.
         qmf_var_params = [3.14159265e+00,  3.14159265e+00, -7.59061327e-12,  0.]
-        ilc_var_params = [1.12894599e-01]
+        ilc_var_params = [-1.12894599e-01]
         var_params = qmf_var_params + ilc_var_params
         ilc_ansatz.update_var_params(var_params)
         # Assert energy returned is as expected for given parameters
@@ -175,13 +175,12 @@ class ILCTest(unittest.TestCase):
         qmf_var_params = [ 3.14159265e+00, -1.02576971e-11,  1.35522331e-11,  3.14159265e+00,
                            3.14159265e+00, -5.62116001e-11, -1.41419277e-11, -2.36789365e-11,
                           -5.53225030e-11, -3.56400157e-11, -2.61030058e-11, -3.55652002e-11]
-        ilc_var_params = [ 0.14001419, -0.10827113,  0.05840200, -0.12364925,
-                          -0.07275071, -0.04703495,  0.02925292,  0.03145765]
+        ilc_var_params, energy = get_ilc_params_by_diag(qubit_hamiltonian, ilc_ansatz.acs, np.array(qmf_var_params), return_energy=True)
         var_params = qmf_var_params + ilc_var_params
         # Assert energy returned is as expected for given parameters
         ilc_ansatz.update_var_params(var_params)
         energy = sim.get_expectation_value(qubit_hamiltonian, ilc_ansatz.circuit)
-        self.assertAlmostEqual(energy, -1.6379638, delta=1e-6)
+        self.assertAlmostEqual(energy, energy, delta=1e-5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
There were a few sign errors/ operator order errors that caused the ILC parameters generated from the `get_ilc_params_by_diag` to not match the energy when placed in circuit form.