### PR TITLE
Set the instance in a Qiskit runtime job

### DIFF
--- a/tangelo/linq/qpu_connection/ibm_connection.py
+++ b/tangelo/linq/qpu_connection/ibm_connection.py
@@ -55,7 +55,7 @@ class IBMConnection(QpuConnection):
             circuits (Circuit | List[Circuit]): Tangelo circuit(s)
             operators (QubitOperator | List[QubitOperator]) : Optional, qubit operators for computing expectation values
             runtime_options (dict): Optional, extra keyword arguments for options supported in qiskit-runtime.
-            isntance (str): The service instance to use, as  in hub/group/project in that format.
+            instance (str): The service instance to use, as in hub/group/project in that format.
 
         Returns:
             str: string representing the job id

--- a/tangelo/linq/qpu_connection/ibm_connection.py
+++ b/tangelo/linq/qpu_connection/ibm_connection.py
@@ -45,7 +45,7 @@ class IBMConnection(QpuConnection):
         """ Return configuration information for each device found on the service """
         return {b.name: b.configuration() for b in self.service.backends()}
 
-    def job_submit(self, program, backend_name, n_shots, circuits, operators=None, runtime_options=None):
+    def job_submit(self, program, backend_name, n_shots, circuits, operators=None, runtime_options=None, instance=None):
         """ Submit job, return job ID.
 
         Args:
@@ -55,13 +55,14 @@ class IBMConnection(QpuConnection):
             circuits (Circuit | List[Circuit]): Tangelo circuit(s)
             operators (QubitOperator | List[QubitOperator]) : Optional, qubit operators for computing expectation values
             runtime_options (dict): Optional, extra keyword arguments for options supported in qiskit-runtime.
+            isntance (str): The service instance to use, as  in hub/group/project in that format.
 
         Returns:
             str: string representing the job id
         """
 
         # Set up options and intermediary Qiskit runtime objects
-        backend = self.service.backend(backend_name)
+        backend = self.service.backend(backend_name, instance=instance)
         session = Session(service=self.service, backend=backend)
 
         if runtime_options is None:

--- a/tangelo/linq/qpu_connection/ibm_connection.py
+++ b/tangelo/linq/qpu_connection/ibm_connection.py
@@ -55,7 +55,7 @@ class IBMConnection(QpuConnection):
             circuits (Circuit | List[Circuit]): Tangelo circuit(s)
             operators (QubitOperator | List[QubitOperator]) : Optional, qubit operators for computing expectation values
             runtime_options (dict): Optional, extra keyword arguments for options supported in qiskit-runtime.
-            instance (str): The service instance to use, as in hub/group/project in that format.
+            instance (str): Optional, desired IBM service instance in the "hub/group/project" format. Default is likely to send to "ibm-q/open/main" 
 
         Returns:
             str: string representing the job id


### PR DESCRIPTION
Add the option to specify the instance ("my_hub/my_group/my_project" format) in the IBM connection class.