### PR TITLE
Bugfix: DMET fragment object initialization from IntegralSolver fixed

### DIFF
--- a/tangelo/problem_decomposition/dmet/fragment.py
+++ b/tangelo/problem_decomposition/dmet/fragment.py
@@ -28,6 +28,7 @@ from pyscf import ao2mo
 
 from tangelo.toolboxes.qubit_mappings.mapping_transform import get_fermion_operator
 from tangelo.toolboxes.molecular_computation.frozen_orbitals import convert_frozen_orbitals
+from tangelo.toolboxes.molecular_computation import IntegralSolverPySCF
 
 
 @dataclass
@@ -92,6 +93,8 @@ class SecondQuantizedDMETFragment:
             n_beta = n_active_electrons//2 - self.spin//2
             self.n_active_ab_electrons = (n_alpha, n_beta)
         self.n_active_electrons = sum(self.n_active_ab_electrons)
+
+        self.solver = IntegralSolverPySCF()
 
     @property
     def frozen_mos(self):


### PR DESCRIPTION
A bug was causing this code to crash
```python
from tangelo import SecondQuantizedMolecule
from tangelo.problem_decomposition.dmet.dmet_problem_decomposition import Localization, DMETProblemDecomposition

xyz_H4 = [("H", [0.0, 0.0, i*2.5]) for i in range(4)]
mol = SecondQuantizedMolecule(xyz_H4, q=0, spin=0, basis="sto-3g")

my_backend_options = {"target": "qulacs", "n_shots": None, "noise_model": None}
solvers_options = {"backend_options": my_backend_options}

opt_dmet = {"molecule": mol,
            "fragment_atoms": [1]*4,
            "fragment_solvers": ["vqe"]*4,
            "solvers_options": [solvers_options]*4,
            "electron_localization": Localization.meta_lowdin,
            "verbose": True
            }

# Run DMET
dmet = DMETProblemDecomposition(opt_dmet)
dmet.build()

energy = dmet.simulate()

print(energy)
```

The root cause of this was because the `initial_var_params` for the `UCCSD` ansatz is set to `MP2`. The code portiuon computing those parameter was checking the `solver` attribute of the provided molecule, and `SecondQuantizedDMETFragment` did not have that attribute.

The test were not failing because when no `solvers_options` is defined, the `initial_var_params` for VQE are set to `ones`. Setting the `solvers_options` without specifying the `initial_var_params` was reverting them to `MP2` for the default ansatz (`UCCSD`).