### PR TITLE
UHF reference symmetry labels.

### DIFF
--- a/tangelo/toolboxes/molecular_computation/integral_solver_pyscf.py
+++ b/tangelo/toolboxes/molecular_computation/integral_solver_pyscf.py
@@ -154,10 +154,19 @@ class IntegralSolverPySCF(IntegralSolver):
             raise ValueError("Hartree-Fock calculation did not converge")
 
         if sqmol.symmetry:
-            sqmol.mo_symm_ids = list(self.symm.label_orb_symm(sqmol.mean_field.mol, sqmol.mean_field.mol.irrep_id,
+            if not sqmol.uhf:
+                sqmol.mo_symm_ids = list(self.symm.label_orb_symm(sqmol.mean_field.mol, sqmol.mean_field.mol.irrep_id,
                                                               sqmol.mean_field.mol.symm_orb, sqmol.mean_field.mo_coeff))
-            irrep_map = {i: s for s, i in zip(molecule.irrep_name, molecule.irrep_id)}
-            sqmol.mo_symm_labels = [irrep_map[i] for i in sqmol.mo_symm_ids]
+                irrep_map = {i: s for s, i in zip(molecule.irrep_name, molecule.irrep_id)}
+                sqmol.mo_symm_labels = [irrep_map[i] for i in sqmol.mo_symm_ids]
+            else:
+                sqmol.mo_symm_ids = []
+                sqmol.mo_symm_labels = []
+                for j in range(2):
+                    sqmol.mo_symm_ids.append(list(self.symm.label_orb_symm(sqmol.mean_field.mol, sqmol.mean_field.mol.irrep_id,
+                                                                      sqmol.mean_field.mol.symm_orb, sqmol.mean_field.mo_coeff[j])))
+                    irrep_map = {i: s for s, i in zip(molecule.irrep_name, molecule.irrep_id)}
+                    sqmol.mo_symm_labels.append([irrep_map[i] for i in sqmol.mo_symm_ids[j]])
         else:
             sqmol.mo_symm_ids = None
             sqmol.mo_symm_labels = None
@@ -383,10 +392,18 @@ class IntegralSolverPySCFQMMM(IntegralSolverPySCF):
             raise ValueError("Hartree-Fock calculation did not converge")
 
         if sqmol.symmetry:
-            sqmol.mo_symm_ids = list(self.symm.label_orb_symm(sqmol.mean_field.mol, sqmol.mean_field.mol.irrep_id,
+            if not sqmol.uhf:
+                sqmol.mo_symm_ids = list(self.symm.label_orb_symm(sqmol.mean_field.mol, sqmol.mean_field.mol.irrep_id,
                                                               sqmol.mean_field.mol.symm_orb, sqmol.mean_field.mo_coeff))
-            irrep_map = {i: s for s, i in zip(molecule.irrep_name, molecule.irrep_id)}
-            sqmol.mo_symm_labels = [irrep_map[i] for i in sqmol.mo_symm_ids]
+                irrep_map = {i: s for s, i in zip(molecule.irrep_name, molecule.irrep_id)}
+                sqmol.mo_symm_labels = [irrep_map[i] for i in sqmol.mo_symm_ids]
+            else:
+                for i in range(2):
+                    print("mol", sqmol.mean_field.mol.symm_orb)
+                    sqmol.mo_symm_ids = list(self.symm.label_orb_symm(sqmol.mean_field.mol, sqmol.mean_field.mol.irrep_id,
+                                                                      sqmol.mean_field.mol.symm_orb[0], sqmol.mean_field.mo_coeff[0]))
+                    irrep_map = {i: s for s, i in zip(molecule.irrep_name, molecule.irrep_id)}
+                    sqmol.mo_symm_labels = [[irrep_map[i] for i in sqmol.mo_symm_ids], [irrep_map[i] for i in sqmol.mo_symm_ids]]
         else:
             sqmol.mo_symm_ids = None
             sqmol.mo_symm_labels = None

--- a/tangelo/toolboxes/molecular_computation/molecule.py
+++ b/tangelo/toolboxes/molecular_computation/molecule.py
@@ -313,9 +313,18 @@ class SecondQuantizedMolecule(Molecule):
     @mo_coeff.setter
     def mo_coeff(self, new_mo_coeff):
         # Asserting the new molecular coefficient matrix have the same dimensions.
-        assert self.solver.mo_coeff.shape == (new_mo_coeff := np.array(new_mo_coeff)).shape, \
-            f"The new molecular coefficients matrix has a {new_mo_coeff.shape}"\
-            f" shape: expected shape is {self.solver.mo_coeff.shape}."
+        if self.uhf:
+            for j in range(2):
+                new_mo_coeff = list(new_mo_coeff)
+                new_mo_coeff[j] = np.array(new_mo_coeff[j])
+                assert self.solver.mo_coeff[j].shape == new_mo_coeff[j].shape
+                f"The new molecular coefficients matrix for index {j} has a {new_mo_coeff[j].shape}"\
+                f" shape: expected shape is {self.solver.mo_coeff[j].shape}."
+            self.solver.mo_coeff = new_mo_coeff
+        else:
+            assert self.solver.mo_coeff.shape == (new_mo_coeff := np.array(new_mo_coeff)).shape, \
+                f"The new molecular coefficients matrix has a {new_mo_coeff.shape}"\
+                f" shape: expected shape is {self.solver.mo_coeff.shape}."
         self.solver.mo_coeff = new_mo_coeff
         if hasattr(self.solver, "modify_solver_mo_coeff"):
             self.solver.modify_solver_mo_coeff(self)

--- a/tangelo/toolboxes/molecular_computation/molecule.py
+++ b/tangelo/toolboxes/molecular_computation/molecule.py
@@ -317,9 +317,9 @@ class SecondQuantizedMolecule(Molecule):
             for j in range(2):
                 new_mo_coeff = list(new_mo_coeff)
                 new_mo_coeff[j] = np.array(new_mo_coeff[j])
-                assert self.solver.mo_coeff[j].shape == new_mo_coeff[j].shape
-                f"The new molecular coefficients matrix for index {j} has a {new_mo_coeff[j].shape}"\
-                f" shape: expected shape is {self.solver.mo_coeff[j].shape}."
+                assert self.solver.mo_coeff[j].shape == new_mo_coeff[j].shape, \
+                    f"The new molecular coefficients matrix for index {j} has a {new_mo_coeff[j].shape}"\
+                    f" shape: expected shape is {self.solver.mo_coeff[j].shape}."
             self.solver.mo_coeff = new_mo_coeff
         else:
             assert self.solver.mo_coeff.shape == (new_mo_coeff := np.array(new_mo_coeff)).shape, \

--- a/tangelo/toolboxes/molecular_computation/tests/test_molecule.py
+++ b/tangelo/toolboxes/molecular_computation/tests/test_molecule.py
@@ -126,6 +126,10 @@ class SecondQuantizedMoleculeTest(unittest.TestCase):
         assert(mo_symm_labels == molecule.mo_symm_labels)
         assert(mo_symm_ids == molecule.mo_symm_ids)
 
+        molecule = SecondQuantizedMolecule(xyz=xyz_H2O, q=0, spin=0, symmetry="C2v", basis="sto-3g", uhf=True)
+        assert([mo_symm_labels, mo_symm_labels] == molecule.mo_symm_labels)
+        assert([mo_symm_ids, mo_symm_ids] == molecule.mo_symm_ids)
+
     def test_ecp(self):
         """Verify that the number of electrons is reduced when ecp is called."""
 


### PR DESCRIPTION
Adds the ability to assign symmetry labels for a UHF reference. Needed to change the setter for mo_coef for uhf.