### PR TITLE
NotImplementedError for ROHF in FNO

### DIFF
--- a/tangelo/toolboxes/molecular_computation/fno.py
+++ b/tangelo/toolboxes/molecular_computation/fno.py
@@ -76,6 +76,8 @@ class FNO:
         if self.uhf:
             self.n_occupied = [len(x+y) for x, y in zip(self.sqmol.frozen_occupied, self.sqmol.active_occupied)]
             self._compute_ump2_densities()
+        elif self.sqmol != 0:
+            raise NotImplementedError("ROHF is not supported for FNO. Please use UHF for open-shell systems.")
         else:
             self.n_occupied = len(self.sqmol.frozen_occupied + self.sqmol.active_occupied)
             self._compute_rmp2_densities()
@@ -99,7 +101,7 @@ class FNO:
         the `_compute_rfno` or the `_compute_ufno`method, whichever is
         appropriate.
         """
-        self._compute_ufno(threshold) if self.uhf else self._compute_rfno(threshold)
+        self._compute_ufno(threshold) if self.uhf or self.sqmol != 0 else self._compute_rfno(threshold)
 
     def get_frozen_indices(self):
         """Method to determine the indices of the frozen orbitals, and it calls
@@ -289,7 +291,7 @@ class FNO:
         for is_beta_spin in range(2):
 
             n_active_virt_fno = self.get_number_of_fnos_from_frac_occupancies(
-                self.fno_occ[is_beta_spin], self.threshold)
+                self.fno_occ[is_beta_spin], threshold)
 
             self.n_active_virt_fno[is_beta_spin] = n_active_virt_fno
 

--- a/tangelo/toolboxes/molecular_computation/fno.py
+++ b/tangelo/toolboxes/molecular_computation/fno.py
@@ -101,7 +101,7 @@ class FNO:
         the `_compute_rfno` or the `_compute_ufno`method, whichever is
         appropriate.
         """
-        self._compute_ufno(threshold) if self.uhf or self.sqmol != 0 else self._compute_rfno(threshold)
+        self._compute_ufno(threshold) if self.uhf else self._compute_rfno(threshold)
 
     def get_frozen_indices(self):
         """Method to determine the indices of the frozen orbitals, and it calls

--- a/tangelo/toolboxes/molecular_computation/fno.py
+++ b/tangelo/toolboxes/molecular_computation/fno.py
@@ -76,7 +76,7 @@ class FNO:
         if self.uhf:
             self.n_occupied = [len(x+y) for x, y in zip(self.sqmol.frozen_occupied, self.sqmol.active_occupied)]
             self._compute_ump2_densities()
-        elif self.sqmol != 0:
+        elif self.sqmol.spin != 0:
             raise NotImplementedError("ROHF is not supported for FNO. Please use UHF for open-shell systems.")
         else:
             self.n_occupied = len(self.sqmol.frozen_occupied + self.sqmol.active_occupied)

--- a/tangelo/toolboxes/molecular_computation/tests/test_fno.py
+++ b/tangelo/toolboxes/molecular_computation/tests/test_fno.py
@@ -17,7 +17,7 @@ import unittest
 import numpy as np
 
 from tangelo import SecondQuantizedMolecule
-from tangelo.molecule_library import mol_H2_321g
+from tangelo.molecule_library import mol_H2_321g, mol_H4_cation_sto3g
 from tangelo.toolboxes.molecular_computation.fno import FNO
 
 
@@ -89,6 +89,12 @@ class FNOTest(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             FNO(mol_H2_321g, [1., 1.])
+
+    def test_h4_cation_sto3g_rohf_notimplemented(self):
+        """Test if the NotImplementedError is raises with a ROHF molecule. """
+
+        with self.assertRaises(NotImplementedError):
+            FNO(mol_H4_cation_sto3g, 0.5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Our MP2 backend (PySCF) convert automatically the RMP2 to UMP2 when an ROHF mean field is used. This has the side effect of setting the FNO MO coeffs differently per spin, therefore enforcing us to use UHF for spin!=0 molecules.