### PR TITLE
Added an option for a callable when defining fragment active space

### DIFF
--- a/tangelo/problem_decomposition/dmet/dmet_problem_decomposition.py
+++ b/tangelo/problem_decomposition/dmet/dmet_problem_decomposition.py
@@ -454,15 +454,17 @@ class DMETProblemDecomposition(ProblemDecomposition):
             # Unpacking the information for the selected fragment.
             mf_fragment, fock_frag_copy, mol_frag, t_list, one_ele, two_ele, fock = info_fragment
 
-            # Interface with our data strcuture.
-            # We create a dummy SecondQuantizedMolecule with a DMETFragment class.
-            # It has the same important attributes and methods to be used with
-            # functions of this package.
+            # Selecting an active space. If the object is callable, the function
+            # should take info_fragment as an argument (DMET fragment information).
             if callable(self.fragment_frozen_orbitals[i]):
                 frozen_orbitals = self.fragment_frozen_orbitals[i](info_fragment)
             else:
                 frozen_orbitals = self.fragment_frozen_orbitals[i]
 
+            # Interface with our data structure.
+            # We create a dummy SecondQuantizedMolecule with a DMETFragment class.
+            # It has the same important attributes and methods to be used with
+            # functions of this package.
             dummy_mol = self.fragment_builder(mol_frag, mf_fragment, fock,
                 fock_frag_copy, t_list, one_ele, two_ele, self.uhf,
                 frozen_orbitals)
@@ -559,9 +561,16 @@ class DMETProblemDecomposition(ProblemDecomposition):
             # Unpacking the information for the selected fragment.
             mf_fragment, fock_frag_copy, mol_frag, t_list, one_ele, two_ele, fock = info_fragment
 
+            # Selecting an active space. If the object is callable, the function
+            # should take info_fragment as an argument (DMET fragment information).
+            if callable(self.fragment_frozen_orbitals[i]):
+                frozen_orbitals = self.fragment_frozen_orbitals[i](info_fragment)
+            else:
+                frozen_orbitals = self.fragment_frozen_orbitals[i]
+
             dummy_mol = self.fragment_builder(mol_frag, mf_fragment, fock,
                 fock_frag_copy, t_list, one_ele, two_ele, self.uhf,
-                self.fragment_frozen_orbitals[i])
+                frozen_orbitals)
 
             # Buiding SCF fragments and quantum circuit. Resources are then
             # estimated. For classical sovlers, this functionality is not

--- a/tangelo/problem_decomposition/dmet/dmet_problem_decomposition.py
+++ b/tangelo/problem_decomposition/dmet/dmet_problem_decomposition.py
@@ -458,9 +458,14 @@ class DMETProblemDecomposition(ProblemDecomposition):
             # We create a dummy SecondQuantizedMolecule with a DMETFragment class.
             # It has the same important attributes and methods to be used with
             # functions of this package.
+            if callable(self.fragment_frozen_orbitals[i]):
+                frozen_orbitals = self.fragment_frozen_orbitals[i](info_fragment)
+            else:
+                frozen_orbitals = self.fragment_frozen_orbitals[i]
+
             dummy_mol = self.fragment_builder(mol_frag, mf_fragment, fock,
                 fock_frag_copy, t_list, one_ele, two_ele, self.uhf,
-                self.fragment_frozen_orbitals[i])
+                frozen_orbitals)
 
             if self.verbose:
                 print("\t\tFragment Number : # ", i + 1)

--- a/tangelo/problem_decomposition/tests/dmet/test_dmet_vqe.py
+++ b/tangelo/problem_decomposition/tests/dmet/test_dmet_vqe.py
@@ -15,8 +15,25 @@
 import unittest
 from copy import copy
 
-from tangelo.molecule_library import mol_H4_minao
+from tangelo.molecule_library import mol_H4_minao, mol_H10_321g
 from tangelo.problem_decomposition.dmet.dmet_problem_decomposition import Localization, DMETProblemDecomposition
+
+
+def define_dmet_frag_as(homo_minus_m=0, lumo_plus_n=0):
+
+    def callable_for_dmet_object(info_fragment):
+        mf_fragment, _, _, _, _, _, _ = info_fragment
+
+        n_molecular_orb = len(mf_fragment.mo_occ)
+
+        n_lumo = mf_fragment.mo_occ.tolist().index(0.)
+        n_homo = n_lumo - 1
+
+        frozen_orbitals = [n for n in range(n_molecular_orb) if n not in range(n_homo-homo_minus_m, n_lumo+lumo_plus_n+1)]
+
+        return frozen_orbitals
+
+    return callable_for_dmet_object
 
 
 class DMETVQETest(unittest.TestCase):
@@ -76,6 +93,32 @@ class DMETVQETest(unittest.TestCase):
         # scBK.
         self.assertEqual(resources_bk[0]["qubit_hamiltonian_terms"], 5)
         self.assertEqual(resources_bk[0]["circuit_width"], 2)
+
+    def test_h10_vqe_resources(self):
+        """Resources estimation on H10 ring, with restricted active space."""
+
+        # Building DMET fragments (with scBK).
+        opt_dmet = {"molecule": mol_H10_321g,
+                    "fragment_atoms": [1]*10,
+                    "fragment_solvers": ["vqe"]*2 + ["ccsd"]*8,
+                    "fragment_frozen_orbitals": [define_dmet_frag_as(0, 0), define_dmet_frag_as(1, 1)]*5,
+                    "electron_localization": Localization.meta_lowdin,
+                    "verbose": False
+                    }
+        opt_dmet["solvers_options"] = {
+            "qubit_mapping": "scbk",
+            "initial_var_params": "ones",
+            "up_then_down": True
+        }
+        dmet = DMETProblemDecomposition(opt_dmet)
+        dmet.build()
+        resources_scbk = dmet.get_resources()
+
+        self.assertEqual(resources_scbk[0]["qubit_hamiltonian_terms"], 9)
+        self.assertEqual(resources_scbk[0]["circuit_width"], 2)
+
+        self.assertEqual(resources_scbk[1]["qubit_hamiltonian_terms"], 325)
+        self.assertEqual(resources_scbk[1]["circuit_width"], 6)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added an option to define a function to define the DMET fragment active space. As the orbital overlap could change with the chemical potential, it is not trivial to define the `frozen_orbitals` manually.

Here is an example of how to leverage this option. In this example, we define the fragment active space as HOMO to LUMO, so every fragment in JW (for restricted mean-field DMET) would be 4 qubits.

```python
from tangelo import SecondQuantizedMolecule
from tangelo.problem_decomposition import DMETProblemDecomposition

xyz_H10 = [
    ("H", ( 0.970820393250,  0.000000000000, 0.)),
    ("H", ( 0.785410196625,  0.570633909777, 0.)),
    ("H", ( 0.300000000000,  0.923305061153, 0.)),
    ("H", (-0.300000000000,  0.923305061153, 0.)),
    ("H", (-0.785410196625,  0.570633909777, 0.)),
    ("H", (-0.970820393250,  0.000000000000, 0.)),
    ("H", (-0.785410196625, -0.570633909777, 0.)),
    ("H", (-0.300000000000, -0.923305061153, 0.)),
    ("H", ( 0.300000000000, -0.923305061153, 0.)),
    ("H", ( 0.785410196625, -0.570633909777, 0.))
]
mol_H10_321g = SecondQuantizedMolecule(xyz_H10, q=0, spin=0, basis="3-21g")


def define_dmet_frag_as(homo_minus_m=0, lumo_plus_n=0):

    def callable_for_dmet_object(info_fragment):
        mf_fragment, _, _, _, _, _, _ = info_fragment

        n_molecular_orb = len(mf_fragment.mo_occ)

        n_lumo = mf_fragment.mo_occ.tolist().index(0.)
        n_homo = n_lumo - 1

        frozen_orbitals = [n for n in range(n_molecular_orb) if n not in range(n_homo-homo_minus_m, n_lumo+lumo_plus_n+1)]

        return frozen_orbitals

    return callable_for_dmet_object


opt_dmet = {"molecule": mol_H10_321g,
            "fragment_atoms": [1]*10,
            "fragment_solvers": "fci",
            "fragment_frozen_orbitals": [define_dmet_frag_as(0, 0)]*10,
            }

dmet = DMETProblemDecomposition(opt_dmet)
dmet.build()
dmet.simulate()
```