### PR TITLE
Fix: Qiskit v1.0.0

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -73,7 +73,7 @@ jobs:
 
     - name: Install pyscf
       run: |
-        python -m pip install pyscf
+        python -m pip install pyscf==2.4.0
         python -m pip install git+https://github.com/pyscf/semiempirical
       if: always()
 

--- a/tangelo/helpers/utils.py
+++ b/tangelo/helpers/utils.py
@@ -83,7 +83,7 @@ clifford_backends_simulator = {"stim"}
 
 # Dictionary mapping package names to their identifier in this module
 packages = {p: p for p in all_backends}
-#packages["qdk"] = "qsharp"
+# packages["qdk"] = "qsharp"
 
 # Figure out what is installed in user's environment
 installed_backends = {p_id for p_id, p_name in packages.items() if is_package_installed(p_name)}

--- a/tangelo/helpers/utils.py
+++ b/tangelo/helpers/utils.py
@@ -73,8 +73,8 @@ def deprecated(custom_message=""):
 
 
 # List all built-in backends supported
-all_backends = {"qulacs", "qiskit", "cirq", "braket", "projectq", "pennylane", "sympy", "stim"} # "qdk"}
-all_backends_simulator = {"qulacs", "qiskit", "cirq"} # "qdk"}
+all_backends = {"qulacs", "qiskit", "cirq", "braket", "projectq", "pennylane", "sympy", "stim"}  # "qdk"}
+all_backends_simulator = {"qulacs", "qiskit", "cirq"}  # "qdk"}
 sv_backends_simulator = {"qulacs", "qiskit", "cirq"}
 cmeasure_backends_simulator = {"qulacs", "cirq"}
 symbolic_backends = {"sympy"}

--- a/tangelo/helpers/utils.py
+++ b/tangelo/helpers/utils.py
@@ -73,8 +73,8 @@ def deprecated(custom_message=""):
 
 
 # List all built-in backends supported
-all_backends = {"qulacs", "qiskit", "cirq", "braket", "projectq", "qdk", "pennylane", "sympy", "stim"}
-all_backends_simulator = {"qulacs", "qiskit", "cirq", "qdk"}
+all_backends = {"qulacs", "qiskit", "cirq", "braket", "projectq", "pennylane", "sympy", "stim"}
+all_backends_simulator = {"qulacs", "qiskit", "cirq"}
 sv_backends_simulator = {"qulacs", "qiskit", "cirq"}
 cmeasure_backends_simulator = {"qulacs", "cirq"}
 symbolic_backends = {"sympy"}
@@ -83,7 +83,7 @@ clifford_backends_simulator = {"stim"}
 
 # Dictionary mapping package names to their identifier in this module
 packages = {p: p for p in all_backends}
-packages["qdk"] = "qsharp"
+#packages["qdk"] = "qsharp"
 
 # Figure out what is installed in user's environment
 installed_backends = {p_id for p_id, p_name in packages.items() if is_package_installed(p_name)}

--- a/tangelo/helpers/utils.py
+++ b/tangelo/helpers/utils.py
@@ -73,8 +73,8 @@ def deprecated(custom_message=""):
 
 
 # List all built-in backends supported
-all_backends = {"qulacs", "qiskit", "cirq", "braket", "projectq", "pennylane", "sympy", "stim"}
-all_backends_simulator = {"qulacs", "qiskit", "cirq"}
+all_backends = {"qulacs", "qiskit", "cirq", "braket", "projectq", "pennylane", "sympy", "stim"} # "qdk"}
+all_backends_simulator = {"qulacs", "qiskit", "cirq"} # "qdk"}
 sv_backends_simulator = {"qulacs", "qiskit", "cirq"}
 cmeasure_backends_simulator = {"qulacs", "cirq"}
 symbolic_backends = {"sympy"}

--- a/tangelo/linq/noisy_simulation/noise_models.py
+++ b/tangelo/linq/noisy_simulation/noise_models.py
@@ -100,8 +100,8 @@ def get_qiskit_noise_model(noise_model):
     Model, compatible with QASM simulator.
     """
 
-    from qiskit.providers.aer.noise import NoiseModel as QiskitNoiseModel
-    from qiskit.providers.aer.noise.errors import depolarizing_error, pauli_error
+    from qiskit_aer.noise import NoiseModel as QiskitNoiseModel
+    from qiskit_aer.noise.errors import depolarizing_error, pauli_error
 
     qnd = get_qiskit_noise_dict(noise_model)
     qnm = QiskitNoiseModel()

--- a/tangelo/linq/target/target_qiskit.py
+++ b/tangelo/linq/target/target_qiskit.py
@@ -214,8 +214,9 @@ class QiskitSimulator(Backend):
 
             opt_level = 0 if self._noise_model else None
 
-            job_sim = self.qiskit.execute(translated_circuit, backend, noise_model=qiskit_noise_model,
-                                          shots=self.n_shots, basis_gates=None, optimization_level=opt_level)
+            transpiled_circuit = self.qiskit.transpile(translated_circuit, backend)
+            job_sim = backend.run(transpiled_circuit, noise_model=qiskit_noise_model,
+                                  shots=self.n_shots, basis_gates=None, optimization_level=opt_level)
             sim_results = job_sim.result()
             self.all_frequencies = {state[::-1]: count/self.n_shots for state, count in sim_results.get_counts(0).items()}
 

--- a/tangelo/linq/tests/test_translator_circuit.py
+++ b/tangelo/linq/tests/test_translator_circuit.py
@@ -354,7 +354,7 @@ class TranslateCircuitTest(unittest.TestCase):
             (the latter has its own tests)
         """
         openqasm_circuit1 = '''OPENQASM 2.0;\ninclude "qelib1.inc";\nqreg q[3];\ncreg c[3];\nh q[2];\ncx q[0],q[1];\ncx '''\
-                            '''q[1],q[2];\ny q[0];\ns q[0];\nrx(1.5) q[1];\nmeasure q[0] -> c[0];\n'''
+                            '''q[1],q[2];\ny q[0];\ns q[0];\nrx(1.5) q[1];\nmeasure q[0] -> c[0];'''
         openqasm_circuit2 = translate_c(abs_circ_mixed, "openqasm")
         print(openqasm_circuit2)
 

--- a/tangelo/linq/translator/translate_openqasm.py
+++ b/tangelo/linq/translator/translate_openqasm.py
@@ -59,8 +59,9 @@ def translate_c_to_openqasm(source_circuit):
         str: the corresponding OpenQASM program, as per IBM Qiskit.
     """
     from .translate_qiskit import translate_c_to_qiskit
+    from qiskit.qasm2 import dumps
 
-    return translate_c_to_qiskit(source_circuit).qasm()
+    return dumps(translate_c_to_qiskit(source_circuit))
 
 
 def translate_c_from_openqasm(openqasm_str):


### PR DESCRIPTION
Highlights:
- Fix changes related to Qiskit 1.0.
- Left `qsharp` out of the tests. Work still to be done to support the QDK.
For [qsharp](https://learn.microsoft.com/en-us/azure/quantum/how-to-migrate-to-modern):
"Most of the in-memory simulators from the Classic QDK have been deprecated, leaving the [sparse simulator](https://learn.microsoft.com/en-us/azure/quantum/sparse-simulator) as the default local simulator in VS Code and the Azure Quantum portal."
- There is an error in PySCF >=2.5.0 when computing MP2 initial parameters for UCCSD. This error isn't showing when using PySCF <= 2.4.0.
