### PR TITLE
Removing Python 3.8 support, and adding 3.12

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/run_psi4_test.yml
+++ b/.github/workflows/run_psi4_test.yml
@@ -9,8 +9,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
-    
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+
     defaults:
       run:
         shell: bash -el {0}
@@ -40,7 +40,7 @@ jobs:
         pip install rdkit
         pip install openbabel-wheel
         conda install -c conda-forge openmm
-    
+
     - name: Install qulacs
       run: |
         pip install qulacs


### PR DESCRIPTION
The Pennylane dependency is not supporting 3.8 anymore.
Qulacs is currently having installation trouble for 3.12, which they should be working on (https://github.com/qulacs/qulacs/issues/645)