### PR TITLE
Fix for qiskit ibm runtime v 0.22

### DIFF
--- a/tangelo/linq/tests/test_ibm_connection.py
+++ b/tangelo/linq/tests/test_ibm_connection.py
@@ -26,7 +26,7 @@ ref_sampler2 = {'00': 0.5, '10': 0.5}
 sim = get_backend()
 ref_estimator = sim.get_expectation_value(op, circ2)
 
-os.environ['IBM_TOKEN'] = 'INSERT YOUR TOKEN HERE'
+os.environ['IBM_TOKEN'] = 'INSERT TOKEN HERE'
 
 
 @unittest.skip("We do not want to store login information for automated testing. Manual testing only.")

--- a/tangelo/linq/translator/translate_qiskit.py
+++ b/tangelo/linq/translator/translate_qiskit.py
@@ -65,13 +65,14 @@ def get_qiskit_gates():
     return GATE_QISKIT
 
 
-def translate_c_to_qiskit(source_circuit: Circuit, save_measurements=False):
+def translate_c_to_qiskit(source_circuit: Circuit, save_measurements=False, no_classical_register=False):
     """Take in a Circuit, return an equivalent qiskit.QuantumCircuit
 
     Args:
         source_circuit (Circuit): quantum circuit in the abstract format.
         save_measurements (bool): Return mid-circuit measurements in the order
             they appear in the circuit in the classical registers
+        no_classical_register (bool): do not create classical register in circuit (default: False)
 
     Returns:
         qiskit.QuantumCircuit: the corresponding qiskit.QuantumCircuit
@@ -82,7 +83,12 @@ def translate_c_to_qiskit(source_circuit: Circuit, save_measurements=False):
 
     n_meas = source_circuit._gate_counts.get("MEASURE", 0) if save_measurements else 0
     n_measures = n_meas + source_circuit.width
-    target_circuit = qiskit.QuantumCircuit(source_circuit.width, n_measures)
+    if no_classical_register:
+        if n_meas != 0:
+            print('Linq translator warning :: Qiskit circuit instantiated with no classical register but measurement gates are present')
+        target_circuit = qiskit.QuantumCircuit(source_circuit.width)
+    else:
+        target_circuit = qiskit.QuantumCircuit(source_circuit.width, n_measures)
 
     measurement = 0
 


### PR DESCRIPTION
Update of code. Translation function for qiskit now supports additional argument for users to specify whether a classical register should be added to the circuit or not.