### PR TITLE
DMET with HF and MP2 solvers

### DIFF
--- a/tangelo/problem_decomposition/dmet/dmet_problem_decomposition.py
+++ b/tangelo/problem_decomposition/dmet/dmet_problem_decomposition.py
@@ -481,7 +481,7 @@ class DMETProblemDecomposition(ProblemDecomposition):
             solver_fragment = self.fragment_solvers[i]
             solver_options = self.solvers_options[i]
             if solver_fragment == "hf":
-                # This code block would output an error with a UHF mean-field.
+                # This code block would output an error with an UHF mean-field.
                 if self.uhf:
                     raise NotImplementedError("UHF mean-field is not supported for the HF solver.")
                 onerdm = mf_fragment.mo_coeff.T @ mf_fragment.make_rdm1() @ mf_fragment.mo_coeff

--- a/tangelo/problem_decomposition/dmet/dmet_problem_decomposition.py
+++ b/tangelo/problem_decomposition/dmet/dmet_problem_decomposition.py
@@ -87,7 +87,6 @@ class DMETProblemDecomposition(ProblemDecomposition):
 
         self.ao2mo = ao2mo
 
-        default_classical_options = dict()
         default_vqe_options = {"qubit_mapping": "jw",
                                "initial_var_params": "ones",
                                "verbose": False}
@@ -182,7 +181,7 @@ class DMETProblemDecomposition(ProblemDecomposition):
         if not self.solvers_options:
             for solver in self.fragment_solvers:
                 if solver.lower() in {"ccsd", "fci", "mp2", "hf"}:
-                    self.solvers_options.append(default_classical_options)
+                    self.solvers_options.append(dict())
                 elif solver.lower() == "vqe":
                     self.solvers_options.append(default_vqe_options)
                 else:

--- a/tangelo/problem_decomposition/dmet/dmet_problem_decomposition.py
+++ b/tangelo/problem_decomposition/dmet/dmet_problem_decomposition.py
@@ -181,6 +181,8 @@ class DMETProblemDecomposition(ProblemDecomposition):
         if not self.solvers_options:
             for solver in self.fragment_solvers:
                 if solver.lower() in {"ccsd", "fci", "mp2", "hf"}:
+                    # To keep the same length for solver_options and fragment_solvers.
+                    # TODO: include solver options inside the fragment_solvers structures or objects.
                     self.solvers_options.append(dict())
                 elif solver.lower() == "vqe":
                     self.solvers_options.append(default_vqe_options)

--- a/tangelo/problem_decomposition/tests/dmet/test_dmet.py
+++ b/tangelo/problem_decomposition/tests/dmet/test_dmet.py
@@ -56,8 +56,7 @@ class DMETProblemDecompositionTest(unittest.TestCase):
             DMETProblemDecomposition(opt_dmet)
 
     def test_not_implemented_solver(self):
-        """Test
-        """
+        """Test if a missing solver is raising an error."""
 
         opt_dmet = {"molecule": mol_H10_321g,
                     "fragment_atoms": [1]*10,
@@ -178,8 +177,7 @@ class DMETProblemDecompositionTest(unittest.TestCase):
         self.assertAlmostEqual(energy, mol_H10_321g.mf_energy, places=4)
 
     def test_solver_mp2(self):
-        """Test the energy output of DMET with MP2 solvers.
-        """
+        """Test the energy output of DMET with MP2 solvers."""
 
         opt_dmet = {"molecule": mol_H10_321g,
                     "fragment_atoms": [1]*10,

--- a/tangelo/problem_decomposition/tests/dmet/test_dmet.py
+++ b/tangelo/problem_decomposition/tests/dmet/test_dmet.py
@@ -55,6 +55,20 @@ class DMETProblemDecompositionTest(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             DMETProblemDecomposition(opt_dmet)
 
+    def test_not_implemented_solver(self):
+        """Test
+        """
+
+        opt_dmet = {"molecule": mol_H10_321g,
+                    "fragment_atoms": [1]*10,
+                    "fragment_solvers": "banana",
+                    "electron_localization": Localization.iao,
+                    "verbose": False
+                    }
+
+        with self.assertRaises(NotImplementedError):
+            DMETProblemDecomposition(opt_dmet)
+
     def test_h10ring_ml_fci(self):
         """ Tests the result from DMET against a value from a reference
         implementation with meta-lowdin localization and FCI solution to
@@ -147,6 +161,37 @@ class DMETProblemDecompositionTest(unittest.TestCase):
         solver.build()
         energy = solver.simulate()
         self.assertAlmostEqual(energy, -0.94199, places=4)
+
+    def test_solver_hf(self):
+        """Test the energy output of DMET with HF solvers (proof of concept)."""
+
+        opt_dmet = {"molecule": mol_H10_321g,
+                    "fragment_atoms": [1]*10,
+                    "fragment_solvers": "hf",
+                    "electron_localization": Localization.iao,
+                    "verbose": False
+                    }
+
+        solver = DMETProblemDecomposition(opt_dmet)
+        solver.build()
+        energy = solver.simulate()
+        self.assertAlmostEqual(energy, mol_H10_321g.mf_energy, places=4)
+
+    def test_solver_mp2(self):
+        """Test the energy output of DMET with MP2 solvers.
+        """
+
+        opt_dmet = {"molecule": mol_H10_321g,
+                    "fragment_atoms": [1]*10,
+                    "fragment_solvers": "mp2",
+                    "electron_localization": Localization.iao,
+                    "verbose": False
+                    }
+
+        solver = DMETProblemDecomposition(opt_dmet)
+        solver.build()
+        energy = solver.simulate()
+        self.assertAlmostEqual(energy, -4.489290, places=4)
 
     def test_fragment_ids(self):
         """Tests if a nested list of atom ids is provided."""

--- a/tangelo/problem_decomposition/tests/dmet/test_dmet.py
+++ b/tangelo/problem_decomposition/tests/dmet/test_dmet.py
@@ -56,7 +56,7 @@ class DMETProblemDecompositionTest(unittest.TestCase):
             DMETProblemDecomposition(opt_dmet)
 
     def test_not_implemented_solver(self):
-        """Test if a missing solver is raising an error."""
+        """Test if a non-implemented solver is raising an error."""
 
         opt_dmet = {"molecule": mol_H10_321g,
                     "fragment_atoms": [1]*10,

--- a/tangelo/problem_decomposition/tests/dmet/test_osdmet.py
+++ b/tangelo/problem_decomposition/tests/dmet/test_osdmet.py
@@ -56,7 +56,7 @@ class OSDMETProblemDecompositionTest(unittest.TestCase):
 
         opt_dmet = {"molecule": mol_lio2,
                     "fragment_atoms": [1, 1, 1],
-                    "fragment_solvers": "ccsd",
+                    "fragment_solvers": "hf",
                     "electron_localization": Localization.nao,
                     "verbose": False
                     }
@@ -66,6 +66,23 @@ class OSDMETProblemDecompositionTest(unittest.TestCase):
         energy = dmet_solver.simulate()
 
         self.assertAlmostEqual(energy, -156.6243118102, places=4)
+
+    def test_notimplemented_uhf_hf_solver(self):
+        """Tests if setting UHF=True raises an error if a HF solver is selected."""
+
+        mol_lio2 = SecondQuantizedMolecule(LiO2, q=0, spin=1, basis="STO-6G", frozen_orbitals=None, uhf=True)
+
+        opt_dmet = {"molecule": mol_lio2,
+                    "fragment_atoms": [1, 1, 1],
+                    "fragment_solvers": "hf",
+                    "electron_localization": Localization.nao,
+                    "verbose": False
+                    }
+
+        with self.assertRaises(NotImplementedError):
+            dmet_solver = DMETProblemDecomposition(opt_dmet)
+            dmet_solver.build()
+            dmet_solver.simulate()
 
 
 if __name__ == "__main__":

--- a/tangelo/problem_decomposition/tests/dmet/test_osdmet.py
+++ b/tangelo/problem_decomposition/tests/dmet/test_osdmet.py
@@ -56,7 +56,7 @@ class OSDMETProblemDecompositionTest(unittest.TestCase):
 
         opt_dmet = {"molecule": mol_lio2,
                     "fragment_atoms": [1, 1, 1],
-                    "fragment_solvers": "hf",
+                    "fragment_solvers": "ccsd",
                     "electron_localization": Localization.nao,
                     "verbose": False
                     }


### PR DESCRIPTION
This is a low-hanging fruit implementation of HF and MP2 solvers with DMET.

Note: This is untested for the unrestricted MP2, and won't work with UHF.