### PR TITLE
Fixing Pyscf Incompatibility problem 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 This file documents the main changes between versions of the code.
 
+## [0.4.3] - 2024-05-21
+
+### Added
+
+- DMET: HF and MP2 solvers
+- DMET: fragment active space can be specified by usrs as a callable function (see DMET notebook)
+
+### Changed
+
+- Copyrights (SandboxAQ 2024)
+- Call to qiskit state vector simulator and IBM Q hardware experiment submissions (compatibility with Qiskit v1.0)
+
+
+### Deprecated / Removed
+
+
 ## [0.4.2] - 2023-12-20
 
 ### Added

--- a/tangelo/_version.py
+++ b/tangelo/_version.py
@@ -14,4 +14,4 @@
 
 """ Define version number here. It is read in setup.py, and bumped automatically
 when using the new release Github action. """
-__version__ = "0.4.2"
+__version__ = "0.4.3"

--- a/tangelo/algorithms/classical/mp2_solver.py
+++ b/tangelo/algorithms/classical/mp2_solver.py
@@ -85,13 +85,12 @@ class MP2SolverPySCF(ElectronicStructureSolver):
             self.mp2_fragment = self.mp.UMP2(self.mean_field, frozen=self.frozen)
         else:
             self.mp2_fragment = self.mp.RMP2(self.mean_field, frozen=self.frozen)
-            if self.mean_field.istype('UHF'):
-                self.mp2_fragment.mean_field = self.mean_field.to_uhf()
-
-        
-
+            if self.mp2_fragment.mo_coeff.shape == self.mean_field.mo_coeff.shape:
+                mf = self.mean_field.to_uhf()
+                self.mp2_fragment = self.mp.UMP2(mf, frozen=self.frozen, mo_coeff=mf.mo_coeff, mo_occ=None)
 
         self.mp2_fragment.verbose = 0
+        print(self.mp2_fragment.mo_coeff)
         _, self.mp2_t2 = self.mp2_fragment.kernel()
 
         total_energy = self.mp2_fragment.e_tot

--- a/tangelo/algorithms/classical/mp2_solver.py
+++ b/tangelo/algorithms/classical/mp2_solver.py
@@ -81,9 +81,15 @@ class MP2SolverPySCF(ElectronicStructureSolver):
 
         # Execute MP2 calculation
         if self.uhf:
+
             self.mp2_fragment = self.mp.UMP2(self.mean_field, frozen=self.frozen)
         else:
             self.mp2_fragment = self.mp.RMP2(self.mean_field, frozen=self.frozen)
+            if self.mean_field.istype('UHF'):
+                self.mp2_fragment.mean_field = self.mean_field.to_uhf()
+
+        
+
 
         self.mp2_fragment.verbose = 0
         _, self.mp2_t2 = self.mp2_fragment.kernel()


### PR DESCRIPTION
Fixes #383 

The problem inherently lies with PYSCF which they have corrected a few weeks ago, for the time being, my fixes will help remove the issues with the tests, this should be future-proof since it checks the type of mf and coverts it only if mean_field is not UHF, so even if later psf version rolls out with the fix , the code would still work 

had a lot of fun working on this issue, initially though it was something to do with the data structure of mo_coeff then saw it was a pyscf issue 

Hopefully this would help close the issue  for now