### PR TITLE
Fixing Pyscf Incompatibility problem 

### DIFF
--- a/tangelo/algorithms/classical/mp2_solver.py
+++ b/tangelo/algorithms/classical/mp2_solver.py
@@ -85,13 +85,12 @@ class MP2SolverPySCF(ElectronicStructureSolver):
             self.mp2_fragment = self.mp.UMP2(self.mean_field, frozen=self.frozen)
         else:
             self.mp2_fragment = self.mp.RMP2(self.mean_field, frozen=self.frozen)
-            if self.mean_field.istype('UHF'):
-                self.mp2_fragment.mean_field = self.mean_field.to_uhf()
-
-        
-
+            if self.mp2_fragment.mo_coeff.shape == self.mean_field.mo_coeff.shape:
+                mf = self.mean_field.to_uhf()
+                self.mp2_fragment = self.mp.UMP2(mf, frozen=self.frozen, mo_coeff=mf.mo_coeff, mo_occ=None)
 
         self.mp2_fragment.verbose = 0
+        print(self.mp2_fragment.mo_coeff)
         _, self.mp2_t2 = self.mp2_fragment.kernel()
 
         total_energy = self.mp2_fragment.e_tot

--- a/tangelo/algorithms/classical/mp2_solver.py
+++ b/tangelo/algorithms/classical/mp2_solver.py
@@ -81,9 +81,15 @@ class MP2SolverPySCF(ElectronicStructureSolver):
 
         # Execute MP2 calculation
         if self.uhf:
+
             self.mp2_fragment = self.mp.UMP2(self.mean_field, frozen=self.frozen)
         else:
             self.mp2_fragment = self.mp.RMP2(self.mean_field, frozen=self.frozen)
+            if self.mean_field.istype('UHF'):
+                self.mp2_fragment.mean_field = self.mean_field.to_uhf()
+
+        
+
 
         self.mp2_fragment.verbose = 0
         _, self.mp2_t2 = self.mp2_fragment.kernel()


### PR DESCRIPTION
Fixes #383 

The problem inherently lies with PYSCF which they have corrected a few weeks ago, for the time being, my fixes will help remove the issues with the tests, this should be future-proof since it checks if there is any changed in mf_coeff so even if later psf version rolls out with the fix , the code would still work  as there must be a change in mf_coeff which will then not trigger the if condition

had a lot of fun working on this issue, initially though it was something to do with the data structure of mo_coeff then saw it was a pyscf issue 

Hopefully this would help close the issue  for now