### PR TITLE
Add automatic documentation deployment workflow

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -1,0 +1,42 @@
+name: Build & deploy sphinx document
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-deploy:
+    name: Build & deploy sphinx document
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Dependencies
+        run: |
+          python -m pip install sphinx sphinx_rtd_theme nbsphinx
+          python -m pip install .
+
+      - name: Run build command
+        run: |
+          sphinx-apidoc -o ./docs/source ./tangelo
+          sphinx-build -M html ./docs/source ./docs/build -E
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          publish_branch: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/build/html
+          force_orphan: true
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+**/__pycache__
+.pytest_cache
+**egg-info
+**/.DS_Store
+**/build


### PR DESCRIPTION
Resolve #385 

The automatically deployed documentation is available at: https://king-p3nguin.github.io/Tangelo/

Settings for GitHub Pages is as follows:
![image](https://github.com/goodchemistryco/Tangelo/assets/103920010/dea8bac9-0b7e-476a-bba3-7c9cad66bae0)


(I am contributing to this project as a unitaryHACK participant)