### PR TITLE
Address semgrep security issue in create_release_branch.yml workflow

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -89,19 +89,19 @@ jobs:
       if: always()
 
     - name: Upload nopyscf test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: tangelo-no-pyscf-test-results
         path: tangelo/toolboxes/molecular_computation/tests/junit/nopyscf-test-results_${{ matrix.python-version }}.xml
 
     - name: Upload pytest test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: tangelo-test-results
         path: tangelo/junit/tangelo-test-results_${{ matrix.python-version }}.xml
 
     - name: Upload pytest html results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: tangelo-tests-coverage_${{ matrix.python-version }}
         path: tangelo/htmlcov

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -108,5 +108,5 @@ jobs:
       if: always()
 
     - name: Download all workflow run artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       if: always()

--- a/.github/workflows/create_release_branch.yml
+++ b/.github/workflows/create_release_branch.yml
@@ -3,47 +3,38 @@ on:
   workflow_dispatch:
     inputs:
       versionName:
-        description: 'Name of version  (ie 5.5.0)'
+        description: 'Name of version (ie 5.5.0)'
         required: true
 jobs:
   createrelease:
     runs-on: ubuntu-latest
-
+    env:
+      VERSION: ${{ github.event.inputs.versionName }}
     steps:
     - name: Check out code
       uses: actions/checkout@v2
     - name: Create release branch
-      run: git checkout -b release/v${{ github.event.inputs.versionName }}
+      run: git checkout -b "release/v${VERSION}"
     - name: Initialize mandatory git config
       run: |
        git config user.name "GitHub Actions"
        git config user.email noreply@github.com
     - name: Change version number and name
       run: |
-       sed -i 's/__version__ = .*/__version__ = "${{ github.event.inputs.versionName }}"/' tangelo/_version.py
+       sed -i "s/__version__ = .*/__version__ = \"${VERSION}\"/" tangelo/_version.py
        git commit tangelo/_version.py --message "Bumping Tangelo version number in _version.py"
-#    - name: Update Changelog
-#      uses: thomaseizinger/keep-a-changelog-new-release@v1
-#      with:
-#        version: ${{ github.event.inputs.versionName }}
-#    - name: Commit changelog and manifest files
-#      id: make-commit
-#      run: |
-#        git add CHANGELOG.md
-#        git commit --message "Prepare release ${{ github.event.inputs.versionName }}"
-#        echo "::set-output name=commit::$(git rev-parse HEAD)"
     - name: Push new branch
-      run: git push origin release/v${{ github.event.inputs.versionName }}
+      run: git push origin "release/v${VERSION}"
     - name: Create pull request into main
       uses: thomaseizinger/create-pull-request@1.0.0
       with:
        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-       head: release/v${{ github.event.inputs.versionName }}
+       head: release/v${{ env.VERSION }}
        base: main
-       title: New release v${{ github.event.inputs.versionName }} into main
+       title: New release v${{ env.VERSION }} into main
        reviewers: ${{ github.event.issue.user.login }}
        body: |
-         This PR was created in response to "create_release_branch" workflow running.
+         This PR was created in response to \"create_release_branch\" workflow running.
          It automatically updated the version number.
          Don't forget to update CHANGELOGS.md, and then merge back main into develop after this PR goes through.
          For the review, only version bumping files are of interest, and making sure tests are passing.

--- a/.github/workflows/create_release_branch.yml
+++ b/.github/workflows/create_release_branch.yml
@@ -34,7 +34,7 @@ jobs:
        title: New release v${{ env.VERSION }} into main
        reviewers: ${{ github.event.issue.user.login }}
        body: |
-         This PR was created in response to \"create_release_branch\" workflow running.
+         This PR was created in response to "create_release_branch" workflow running.
          It automatically updated the version number.
          Don't forget to update CHANGELOGS.md, and then merge back main into develop after this PR goes through.
          For the review, only version bumping files are of interest, and making sure tests are passing.

--- a/.github/workflows/run_psi4_test.yml
+++ b/.github/workflows/run_psi4_test.yml
@@ -64,17 +64,17 @@ jobs:
       if: always()
 
     - name: Upload psi4 test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: tangelo-psi4-test-results
         path: tangelo/toolboxes/molecular_computation/tests/junit/psi4-test-results_${{ matrix.python-version }}.xml
 
     - name: Upload classical psi4 test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: tangelo-classical-psi4-test-results
         path: tangelo/algorithms/classical/tests/junit/psi4-classical-test-results_${{ matrix.python-version }}.xml
 
     - name: Download all workflow run artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       if: always()


### PR DESCRIPTION
This pull request introduces two changes:

- It updates `download-artefact` and `upload-artefact` actions to version v4. This change is necessary because Github Actions workflows (`Continuous Integration` and `psi4`) are failing due to the use of a deprecated version.
- It addresses a semgrep issue in `create_release_workflow.yml`. Previously, using variable interpolation `${{…}}` with `github` context data in a `run:` step could have allowed an attacker to inject their own code into the runner. To prevent this, we should use an intermediate environment variable with `env:` to store the data, and then use the environment variable in the `run:` script.