### PR TITLE
[linq] Circuit convenience methods return self (closes #408)

### DIFF
--- a/tangelo/linq/circuit.py
+++ b/tangelo/linq/circuit.py
@@ -379,52 +379,78 @@ class Circuit:
         """Convenience method to remove small rotations from the circuit.
         See separate remove_small_rotations function.
 
+        The operation is performed in place; ``self`` is returned so the call
+        also reads naturally as an expression
+        (e.g. ``c2 = Circuit(...).remove_small_rotations()``).
+
         Args:
             param_threshold (float): Optional, max absolute value to consider a rotation
                 as small enough to be discarded
             remove_qubits (bool): Optional, remove qubit with no operations assigned left
 
         Returns:
-            Circuit: The circuit without small rotations.
+            Circuit: ``self`` after the simplification pass, even when the
+                resulting circuit contains zero gates.
         """
         opt_circuit = remove_small_rotations(self, param_threshold=param_threshold, remove_qubits=remove_qubits)
         self.__dict__ = opt_circuit.__dict__
+        return self
 
     def remove_redundant_gates(self, remove_qubits=False):
         """Convenience method to remove redundant gates from the circuit.
         See separate remove_redundant_gates function.
 
+        The operation is performed in place; ``self`` is returned so the call
+        also reads naturally as an expression.
+
         Args:
             remove_qubits (bool): Optional, remove qubit with no operations assigned left
 
         Returns:
-            Circuit: The circuit without redundant gates.
+            Circuit: ``self`` after the simplification pass, even when the
+                resulting circuit contains zero gates.
         """
         opt_circuit = remove_redundant_gates(self, remove_qubits=remove_qubits)
         self.__dict__ = opt_circuit.__dict__
+        return self
 
     def merge_rotations(self):
-        """ Convenience method to merge compatible rotations applied successively on identical qubits indices.
+        """Convenience method to merge compatible rotations applied successively on identical qubits indices.
         The operation is done in-place and alters the input circuit.
+
+        Returns:
+            Circuit: ``self`` after the merge pass, even when the resulting
+                circuit contains zero gates.
         """
         opt_circuit = merge_rotations(self)
         self.__dict__ = opt_circuit.__dict__
+        return self
 
     def simplify(self, max_cycles=100, param_threshold=1e-3, remove_qubits=False):
         """ Convenience method to simplify gates in a circuit, by repeating a set of simple passes
         until no further changes occurs, or a maximum number of cycles has been reached.
+
+        The operation is performed in place; ``self`` is returned so the call
+        also reads naturally as an expression
+        (e.g. ``c_simp = Circuit([Gate("H", 0)] * 2).simplify()``).
 
         Args:
             max_cycles (int): Optional, maximum number of cycles to perform
             param_threshold (float): Optional, max absolute value to consider a rotation
                 as small enough to be discarded
             remove_qubits (bool): Optional, remove qubit with no operations assigned left
+
+        Returns:
+            Circuit: ``self`` after the simplification pass. When every gate
+                cancels out, a Circuit with zero gates and the original
+                ``n_qubits`` is returned (see issue #408).
         """
 
         opt_circuit = simplify(self,
                                max_cycles=max_cycles, param_threshold=param_threshold,
                                remove_qubits=remove_qubits)
         self.__dict__ = opt_circuit.__dict__
+        return self
 
     def controlled_measurement_op(self, measure):
         """Call the object self._cmeasure_control and return the next circuit to apply."""

--- a/tangelo/linq/tests/test_circuits.py
+++ b/tangelo/linq/tests/test_circuits.py
@@ -336,6 +336,30 @@ class TestCircuits(unittest.TestCase):
         c.simplify()
         assert(c == Circuit([Gate('X', i) for i in range(2)]))
 
+    def test_simplify_returns_circuit_when_everything_cancels(self):
+        """Regression test for issue #408. The convenience methods that wrap
+        in-place simplification passes must return ``self`` so that the call
+        site reads as an expression. Before the fix,
+        ``Circuit([Gate("H", 0)] * 2).simplify()`` returned ``None`` and any
+        attribute access on the result raised ``AttributeError``."""
+
+        # The original failing one-liner from the issue body.
+        c = Circuit([Gate("H", 0)] * 2).simplify()
+        assert c is not None, "Circuit.simplify() must not return None"
+        assert isinstance(c, Circuit), f"expected Circuit, got {type(c).__name__}"
+        assert len(c._gates) == 0, "two H gates should cancel out"
+        assert c.width == 1, "qubit count should be preserved when remove_qubits=False"
+
+        # The same guarantee for the other three in-place convenience methods.
+        c1 = Circuit([Gate("X", 0)]).remove_redundant_gates()
+        c2 = Circuit([Gate("RZ", 0, parameter=1e-9)]).remove_small_rotations()
+        c3 = Circuit([Gate("RZ", 0, parameter=0.1), Gate("RZ", 0, parameter=0.2)]).merge_rotations()
+        for name, returned in [("remove_redundant_gates", c1),
+                               ("remove_small_rotations", c2),
+                               ("merge_rotations", c3)]:
+            assert returned is not None, f"Circuit.{name}() must not return None"
+            assert isinstance(returned, Circuit), f"Circuit.{name}() should return Circuit, got {type(returned).__name__}"
+
     def test_copy(self):
         """ Test if copy function is working properly."""
         test_circuit = Circuit([Gate("X", 0), Gate("H", 1), Gate("H", 1)])


### PR DESCRIPTION
Closes #408.

`Circuit.simplify()` returns `NoneType` instead of an empty circuit, because the convenience wrapper splats the underlying function's result into `self.__dict__` and returns nothing. Three sibling methods on `Circuit` have the exact same shape, so this PR fixes all four at once for consistency.

## What changed

**`tangelo/linq/circuit.py`** — added `return self` to:
- `Circuit.simplify()`
- `Circuit.remove_redundant_gates()`
- `Circuit.remove_small_rotations()`
- `Circuit.merge_rotations()`

The two docstrings that already promised `Returns: Circuit: The circuit without ...` are tightened; the two that didn't get a matching `Returns` clause added.

**`tangelo/linq/tests/test_circuits.py`** — new regression test `test_simplify_returns_circuit_when_everything_cancels` that pins the exact failing one-liner from the issue body:

```python
result = Circuit([Gate("H", 0)] * 2).simplify()
assert result is not None
assert isinstance(result, Circuit)
assert len(result._gates) == 0
assert result.width == 1
```

Plus analogous assertions for the other three methods.

**`FIX_ISSUE_408_README.md`** — design rationale (why `return self` over a separate `simplified()` API), full file listing.

## Compatibility

The in-place semantic is preserved — these methods still mutate `self.__dict__` before returning. The existing `test_simplify_circuit` passes unchanged because the assertions on circuit state after `.simplify()` are still valid.

The change enables the chainable expression form (`Circuit(...).simplify().draw()`) without breaking any existing code that called these methods for their side-effects and discarded the return value.

## Open question for review

If you'd rather have a separate `simplified()` / `remove_redundant_gates_copy()` API (returning a new circuit, leaving the original untouched), this PR can be reworked in that direction — happy to align on whichever shape fits the linq module's broader conventions.

---

Francesco Pernice Botta · 999purple999