### PR TITLE
security: declare least-privilege permissions for all workflows

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -15,9 +15,9 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -92,24 +92,24 @@ jobs:
       if: always()
 
     - name: Upload nopyscf test results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
-        name: tangelo-no-pyscf-test-results
+        name: tangelo-no-pyscf-test-results_${{ matrix.python-version }}
         path: tangelo/toolboxes/molecular_computation/tests/junit/nopyscf-test-results_${{ matrix.python-version }}.xml
 
     - name: Upload pytest test results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
-        name: tangelo-test-results
+        name: tangelo-test-results_${{ matrix.python-version }}
         path: tangelo/junit/tangelo-test-results_${{ matrix.python-version }}.xml
 
     - name: Upload pytest html results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: tangelo-tests-coverage_${{ matrix.python-version }}
         path: tangelo/htmlcov
       if: always()
 
     - name: Download all workflow run artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       if: always()

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -1,5 +1,8 @@
 name: Continuous Integration
 
+permissions:
+  contents: read
+
 on: [pull_request]
 
 jobs:

--- a/.github/workflows/create_release_branch.yml
+++ b/.github/workflows/create_release_branch.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
     - name: Create release branch
       run: git checkout -b release/v"$VERSION"
     - name: Initialize mandatory git config
@@ -41,7 +41,7 @@ jobs:
     - name: Push new branch
       run: git push origin release/v"$VERSION"
     - name: Create pull request into main
-      uses: thomaseizinger/create-pull-request@1.0.0
+      uses: thomaseizinger/create-pull-request@708b87f1bf8075327bd126082bb2430020bab194 # 1.0.0
       with:
        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
        head: release/v${{ github.event.inputs.versionName }}

--- a/.github/workflows/create_release_branch.yml
+++ b/.github/workflows/create_release_branch.yml
@@ -1,4 +1,8 @@
 name: Create Release Branch
+permissions:
+  contents: write        # pushes the release/vX.Y.Z branch
+  pull-requests: write   # opens the release PR into main
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -17,10 +17,10 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
 
@@ -39,7 +39,7 @@ jobs:
           cp ./docs/source/_static/img/tangelo_logo_gradient.png ./docs/build/html/docs/source/_static/img          
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4
         with:
           publish_branch: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -1,5 +1,8 @@
 name: Build & deploy sphinx document
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/protect_main.yaml
+++ b/.github/workflows/protect_main.yaml
@@ -1,5 +1,8 @@
 name: 'Protect Main Branch'
 
+permissions:
+  contents: read
+
 on:
   pull_request:
 

--- a/.github/workflows/run_psi4_test.yml
+++ b/.github/workflows/run_psi4_test.yml
@@ -19,8 +19,8 @@ jobs:
         shell: bash -el {0}
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+    - uses: conda-incubator/setup-miniconda@9f54435e0e72c53962ee863144e47a4b094bfd35 # v2
       with:
         activate-environment: anaconda-client-env
     - run: conda info
@@ -67,17 +67,17 @@ jobs:
       if: always()
 
     - name: Upload psi4 test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
-        name: tangelo-psi4-test-results
+        name: tangelo-psi4-test-results_${{ matrix.python-version }}
         path: tangelo/toolboxes/molecular_computation/tests/junit/psi4-test-results_${{ matrix.python-version }}.xml
 
     - name: Upload classical psi4 test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
-        name: tangelo-classical-psi4-test-results
+        name: tangelo-classical-psi4-test-results_${{ matrix.python-version }}
         path: tangelo/algorithms/classical/tests/junit/psi4-classical-test-results_${{ matrix.python-version }}.xml
 
     - name: Download all workflow run artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       if: always()

--- a/.github/workflows/run_psi4_test.yml
+++ b/.github/workflows/run_psi4_test.yml
@@ -1,5 +1,8 @@
 name: psi4 test
 
+permissions:
+  contents: read
+
 on: [pull_request]
 
 jobs:


### PR DESCRIPTION
## Why

Every workflow in this repo runs without a `permissions:` block, so each one inherits the
repository default token. That default is currently **read-write**, which means jobs that only
need to read code (CI, psi4 tests, the branch-name check) run with a token that can push commits,
create releases, and open pull requests.

This PR declares the minimum each workflow actually needs. It is a prerequisite for flipping the
repository default to read-only, which is GitHub's recommended setting.

While doing that, the workflows turned out to be unrunnable for an unrelated reason, so this PR
also repairs that. Details below.

## What changed

### 1. Least-privilege `permissions:`

| Workflow | Permissions added | Why |
|---|---|---|
| `continuous_integration.yml` | `contents: read` | build + test only |
| `run_psi4_test.yml` | `contents: read` | build + test only |
| `protect_main.yaml` | `contents: read` | reads `github.base_ref` only |
| `deploy_docs.yml` | `contents: read` (top level) | the publishing job already declares its own `contents: write`; this only lowers the default for the rest |
| `create_release_branch.yml` | `contents: write`, `pull-requests: write` | genuinely needs both — it pushes `release/vX.Y.Z` and opens the release PR |

### 2. Artifact actions: unblocking the workflows

`continuous_integration.yml` and `run_psi4_test.yml` were **failing before any step ran**, at
`Prepare all required actions`. Both referenced `actions/download-artifact@v3` (and `run_psi4_test.yml`
also `upload-artifact@v3`). GitHub [retired v3 and now hard-fails any workflow that references
it](https://github.blog/changelog/2024-11-26-notice-of-breaking-changes-for-github-actions/) —
the job never starts, so the failure looks like a CI outage rather than a version problem.

`continuous_integration.yml` had also been half-migrated: uploads were already on `v4` while the
matching download was still `v3`. `v4` additionally requires artifact names to be **unique per
workflow run**, and all four upload steps used a fixed name across a 4-way Python matrix, so even
with the download fixed, three of every four jobs would collide.

Fixed together:

- `download-artifact` v3 → v4 in both workflows; `upload-artifact` v3 → v4 in `run_psi4_test.yml`
- every artifact name suffixed with `_${{ matrix.python-version }}`

### 3. Action versions and SHA pinning

Actions are pinned to commit SHAs with the version in a trailing comment. Where a pin would have
frozen an end-of-life runtime, the version was **raised first** rather than pinned in place —
`actions/checkout@v2` → `v4` in `create_release_branch.yml`, `actions/setup-python@v4` → `v5` in
`continuous_integration.yml`. Pinning a node16-era action would have silenced `actionlint`'s
"runner is too old" warning without fixing anything.

No job logic, trigger, step ordering, or test code is changed.

## Validation

- `actionlint` before/after on all five files, normalised and diffed: no new findings. Remaining
  messages are pre-existing and unrelated — notably an `SC2016` in `create_release_branch.yml`
  where `sed -i 's/...$VERSION.../'` uses single quotes so the variable never expands. Flagged
  here, deliberately **not** fixed in a security PR.
- Permissions were derived per workflow, not applied uniformly. `create_release_branch.yml` was
  confirmed to need write via its `git push origin` step and its `create-pull-request` step.
- CI was run on this branch and, for the first time, gets past `Prepare all required actions`.

## About the red checks

**The failing `build (3.x)` jobs are pre-existing and are not caused by this PR.** This PR touches
only `.github/workflows/`; it contains no Python.

The v3 hard-fail meant these workflows had not executed a test in a long time — `continuous_integration.yml`
has no successful run in its retained history (previous attempts: 2025-08-01 and 2025-12-19, both
red). With the workflows able to run again, the suite executes and reports **22 failed, 529 passed,
44 skipped**. The failures are dependency drift accumulated behind the outage:

| Failure | Cause |
|---|---|
| `AttributeError: module 'numpy' has no attribute 'product'` (10 tests) | removed in NumPy 2.0 |
| `test_qiskit`, `TestSimulateStatevector::*` | qiskit statevector qubit-ordering change |
| `ModuleNotFoundError: No module named 'pennylane'` | optional dep absent from the CI env |
| `test_lio2_sto6g_rohf` — `'int' object has no attribute 'ndim'` | pyscf API change |
| `psi4 test`: `QMMM` import (3.10–3.12), `libint2.so.2` (3.9) | `QMMM` → `external_potentials` in psi4 ≥ 1.6 |

Those are real bugs worth their own issue, but fixing them is a different change by different
owners. The choice here is between a workflow that cannot start and a workflow that starts and
tells the truth about the test suite. This PR delivers the second.

## Follow-ups (not in this PR)

1. Once this merges and reaches `main`, the repo default token can be set to read-only.
2. Repair the 22 test failures above (NumPy 2.x, qiskit, pyscf, psi4 ≥ 1.6, pennylane).
3. `main` also carries `.github/workflows/semgrep.yml`, which does not exist on `develop` and so
   is not covered here. See #421, which removes it — it is `disabled_inactivity` and last ran
   2025-07-05.
4. `main` and `develop` have diverged (`main` is 8 ahead / 14 behind `develop`), including in
   `.github/workflows/`. Worth reconciling.

Filed as part of an org-wide public-repository security review.
